### PR TITLE
improvement, deprecate the symbols flag & make binaries for Bakerloo testnet.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,6 @@ e2e-test-stuffs:
 	cp $(PLUGIN_DIR)/forex_exchangerate $(E2E_TEST_FOREX_PLUGIN_DIR)/forex_exchangerate
 	cp $(PLUGIN_DIR)/forex_openexchange $(E2E_TEST_FOREX_PLUGIN_DIR)/forex_openexchange
 
-	# cp autonity round4 game PCGC CAX plugins for e2e testing
-	cp $(PLUGIN_DIR)/pcgc_cax $(E2E_TEST_CAX_PLUGIN_DIR)/pcgc_cax
-
     # build simulator plugin
 	go build -o $(E2E_TEST_SML_PLUGIN_DIR)/sim_plugin $(PLUGIN_SRC_DIR)/simulator_plugin/simulator_plugin.go
 	chmod +x $(E2E_TEST_SML_PLUGIN_DIR)/sim_plugin
@@ -92,21 +89,34 @@ forex-plugins:
 dev-cax-plugin:
 	go build -o $(PLUGIN_DIR)/pcgc_cax -tags dev $(PLUGIN_SRC_DIR)/pcgc_cax/
 	chmod +x $(PLUGIN_DIR)/pcgc_cax
+	# cp autonity round4 game PCGC CAX plugins for e2e testing
+	cp $(PLUGIN_DIR)/pcgc_cax $(E2E_TEST_CAX_PLUGIN_DIR)/pcgc_cax
 
 piccadilly-cax-plugin:
 	go build -o $(PLUGIN_DIR)/pcgc_cax $(PLUGIN_SRC_DIR)/pcgc_cax/
 	chmod +x $(PLUGIN_DIR)/pcgc_cax
+	# cp autonity round4 game PCGC CAX plugins for e2e testing
+	cp $(PLUGIN_DIR)/pcgc_cax $(E2E_TEST_CAX_PLUGIN_DIR)/pcgc_cax
+
+bakerloo-simulator:
+	go build -o $(SIMULATOR_BIN_DIR)/simulator $(SIMULATOR_SRC_DIR)/main.go
+	go build -o $(BIN_DIR)/simulator $(SIMULATOR_SRC_DIR)/main.go
+
+bakerloo-sim-plugin:
+	go build -o $(PLUGIN_DIR)/sim_plugin $(PLUGIN_SRC_DIR)/simulator_plugin/simulator_plugin.go
+	chmod +x $(PLUGIN_DIR)/sim_plugin
 
 autoracle-dev: mkdir oracle-server forex-plugins dev-cax-plugin conf-file e2e-test-stuffs
 	@echo "Done building for dev network."
 	@echo "Run \"$(BIN_DIR)/autoracle\" to launch autonity oracle."
 
+autoracle-bakerloo: mkdir oracle-server forex-plugins bakerloo-simulator bakerloo-sim-plugin conf-file e2e-test-stuffs
+	@echo "Done building for bakerloo network."
+	@echo "Run \"$(BIN_DIR)/autoracle\" to launch autonity oracle."
+
 autoracle: mkdir oracle-server forex-plugins piccadilly-cax-plugin conf-file e2e-test-stuffs
 	@echo "Done building for piccadilly network."
 	@echo "Run \"$(BIN_DIR)/autoracle\" to launch autonity oracle."
-
-simulator:
-	go build -o $(SIMULATOR_BIN_DIR)/simulator $(SIMULATOR_SRC_DIR)/main.go
 
 oracle-contract:
 	mkdir -p $(BIN_DIR)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Values that can be configured by using environment variables:
 
 | **Env Variable** | **Required?** | **Meaning** | **Default Value**                                                                                    | **Valid Options** |
 |----------------------------|---------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `SYMBOLS` | No | The symbols that the oracle component collects data points for | "AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN"                                    | symbols separated by ',' |
 | `PLUGIN_DIR` | No | The directory that stores the plugins | "./plugins"                                                                                | any directory that saves plugins |
 | `KEY_FILE` | Yes | The encrypted key file path that contains the private key of the oracle client. | "./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" | any key file that saves the private key |
 | `KEY_PASSWORD` | Yes | The password of the key file that contains the private key of the oracle client. | "123"                                                                                                | any password that encrypted the private key |
@@ -69,7 +68,6 @@ Flags:
   -log.level=2: Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error
   -plugin.conf="./plugins-conf.yml": Set the plugins' configuration file
   -plugin.dir="./plugins": Set the directory of the data plugins.
-  -symbols="AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN": Set the symbols string separated by comma
   -tip=1: Set the gas priority fee cap to issue the oracle data report transactions.
   -ws="ws://127.0.0.1:8546": Set the WS-RPC server listening interface and port of the connected Autonity Client node
 
@@ -78,7 +76,7 @@ Flags:
 
 example to run the autonity oracle service with console flags:
 ```shell
-$./autoracle --symbols="AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN" --plugin.dir="./plugins" --key.file="../../test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546" --plugin.conf="./plugins-conf.yml"
+$./autoracle --plugin.dir="./plugins" --key.file="../../test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546" --plugin.conf="./plugins-conf.yml"
 ```
 plugin configuration file:    
 
@@ -188,7 +186,7 @@ $.~/src/autonity-oracle/build/bin/autoracle
 or configure by using console flags and run the binary:
 
 ```shell
-$./autoracle --symbols="AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN" --plugin.dir="./plugins" --key.file="./test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546"
+$./autoracle --plugin.dir="./plugins" --key.file="./test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546"
 ```
 
 ### Deploy via linux system daemon
@@ -266,7 +264,7 @@ sudo journalctl -u autoracle.service -b
 -- Logs begin at Sat 2022-11-26 11:54:00 GMT, end at Thu 2023-01-19 02:59:51 GMT. --  
 Jan 19 02:42:19 systemd[1]: Started Clearmatics Autonity Oracle Server.  
 Jan 19 02:42:19 autoracle[14568]: 2023/01/19 02:42:19  
-Jan 19 02:42:19 autoracle[14568]: Running autonity oracle service at port: 30311, with symbols: NTNUSDT,NTNUSDC,NTNBTC,NTNETH and plugin diretory: /home/user/src/autonity-oracle/build/bin/plugins  
+Jan 19 02:42:19 autoracle[14568]: Running autonity oracle service at port: 30311, with plugin diretory: /home/user/src/autonity-oracle/build/bin/plugins
 Jan 19 02:42:19 autoracle[14568]: 2023-01-19T02:42:19.152Z [WARN] binance: plugin configured with a nil SecureConfig  
 Jan 19 02:42:19 autoracle[14568]: 2023-01-19T02:42:19.152Z [DEBUG] binance: starting plugin: path=/home/user/src/autonity-oracle/build/bin/plugins/binance args=[/home/uesr/src/autonity-oracle/build/bin/plugins/binance]  
 Jan 19 02:42:19 autoracle[14568]: 2023-01-19T02:42:19.152Z [DEBUG] binance: plugin started: path=/home/user/src/autonity-oracle/build/bin/plugins/binance pid=14577  

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ var (
 	DefaultKeyPassword    = "123"
 	DefaultPluginDir      = "./plugins"
 	DefaultPluginConfFile = "./plugins-conf.yml"
-	DefaultSymbols        = "AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN"
+	DefaultSymbols        = []string{"AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "NTN-ATN"}
 )
 
 const Version = "v0.1.4"
@@ -28,7 +28,6 @@ const Version = "v0.1.4"
 func MakeConfig() *types.OracleServiceConfig {
 	var logLevel int
 	var keyFile string
-	var symbols string
 	var pluginDir string
 	var keyPassword string
 	var autonityWSUrl string
@@ -38,7 +37,6 @@ func MakeConfig() *types.OracleServiceConfig {
 	flag.IntVar(&logLevel, "log.level", DefaultLogVerbosity, "Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error")
 	flag.Uint64Var(&gasTipCap, "tip", DefaultGasTipCap, "Set the gas priority fee cap to issue the oracle data report transactions.")
 	flag.StringVar(&pluginDir, "plugin.dir", DefaultPluginDir, "Set the directory of the data plugins.")
-	flag.StringVar(&symbols, "symbols", DefaultSymbols, "Set the symbols string separated by comma")
 	flag.StringVar(&keyFile, "key.file", DefaultKeyFile, "Set oracle server key file")
 	flag.StringVar(&keyPassword, "key.password", DefaultKeyPassword, "Set the password to decrypt oracle server key file")
 	flag.StringVar(&autonityWSUrl, "ws", DefaultAutonityWSUrl, "Set the WS-RPC server listening interface and port of the connected Autonity Client node")
@@ -49,11 +47,6 @@ func MakeConfig() *types.OracleServiceConfig {
 		log.SetFlags(0)
 		log.Println(Version)
 		os.Exit(0)
-	}
-
-	// Parse system environment variables.
-	if s, presented := os.LookupEnv(types.EnvSymbols); presented {
-		symbols = s
 	}
 
 	if lvl, presented := os.LookupEnv(types.EnvLogLevel); presented {
@@ -97,8 +90,6 @@ func MakeConfig() *types.OracleServiceConfig {
 	}
 
 	// verify configurations.
-	symbolArray := helpers.ParseSymbols(symbols)
-
 	keyJson, err := os.ReadFile(keyFile)
 	if err != nil {
 		log.Printf("Cannot read key file: %s, %s", keyFile, err.Error())
@@ -123,7 +114,6 @@ func MakeConfig() *types.OracleServiceConfig {
 		GasTipCap:      gasTipCap,
 		Key:            key,
 		AutonityWSUrl:  autonityWSUrl,
-		Symbols:        symbolArray,
 		PluginDIR:      pluginDir,
 		PluginConfFile: pluginConfFile,
 		LoggingLevel:   hclog.Level(logLevel),

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ var (
 	DefaultSymbols        = []string{"AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "NTN-ATN"}
 )
 
-const Version = "v0.1.4"
+const Version = "v0.1.5"
 
 func MakeConfig() *types.OracleServiceConfig {
 	var logLevel int

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,8 +15,6 @@ func TestMakeConfigWithConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		err = os.Setenv(types.EnvKeyFilePASS, "123")
 		require.NoError(t, err)
-		err = os.Setenv(types.EnvSymbols, "AUD-USD,CAD-USD,EUR-USD, ")
-		require.NoError(t, err)
 		err = os.Setenv(types.EnvPluginDIR, "./")
 		require.NoError(t, err)
 		err = os.Setenv(types.EnvLogLevel, "3")
@@ -29,7 +27,6 @@ func TestMakeConfigWithConfiguration(t *testing.T) {
 		require.NoError(t, err)
 
 		conf := MakeConfig()
-		require.Equal(t, []string{"AUD-USD", "CAD-USD", "EUR-USD"}, conf.Symbols)
 		require.Equal(t, "./", conf.PluginDIR)
 		require.Equal(t, common.HexToAddress("0xb749d3d83376276ab4ddef2d9300fb5ce70ebafe"), conf.Key.Address)
 		require.Equal(t, hclog.Info, conf.LoggingLevel)

--- a/config/plugins-conf.yml
+++ b/config/plugins-conf.yml
@@ -28,7 +28,7 @@
 #    scheme: https                           # optional, https or http, default value is https.
 #    endpoint: api.currencyfreaks.com        # optional, default value is api.currencyfreaks.com
 #    timeout: 10                             # optional, default value is 10.
-#    refresh: 30                             # optional, default value is 30, that is 30s to fetch data from data source.
+#    refresh: 3600                           # optional, default value is 30, that is 30s to fetch data from data source.
 
 # Un-comment below lines to enable your forex data plugin's configuration on demand. Your production configurations start from below:
 

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -197,7 +197,7 @@ func TestAddCommitteeMember(t *testing.T) {
 func TestHappyCaseWithBinanceDataService(t *testing.T) {
 	var netConf = &NetworkConfig{
 		EnableL1Logs: false,
-		Symbols:      "BTC-USD,BTC-USDC,BTC-USDT,BTC-USD4",
+		Symbols:      []string{"BTC-USD", "BTC-USDC", "BTC-USDT", "BTC-USD4"},
 		VotePeriod:   defaultVotePeriod,
 		PluginDIRs:   []string{binancePlugDir, binancePlugDir, binancePlugDir, binancePlugDir},
 	}
@@ -342,7 +342,7 @@ func TestWithBinanceSimulatorTimeout(t *testing.T) {
 func TestForexPluginsHappyCase(t *testing.T) {
 	var netConf = &NetworkConfig{
 		EnableL1Logs: false,
-		Symbols:      "EUR-USD,JPY-USD,GBP-USD,AUD-USD,CAD-USD,SEK-USD",
+		Symbols:      []string{"EUR-USD", "JPY-USD", "GBP-USD", "AUD-USD", "CAD-USD", "SEK-USD"},
 		VotePeriod:   defaultVotePeriod,
 		PluginDIRs:   []string{forexPlugDir, forexPlugDir, forexPlugDir, forexPlugDir},
 	}
@@ -372,7 +372,7 @@ func TestCAXPluginsHappyCase(t *testing.T) {
 	//t.Skip("this test depends on the remote service endpoint of cax.devnet.clearmatics.network")
 	var conf = &NetworkConfig{
 		EnableL1Logs: false,
-		Symbols:      "NTN-USD,ATN-USD,NTN-ATN",
+		Symbols:      []string{"NTN-USD", "ATN-USD", "NTN-ATN"},
 		VotePeriod:   defaultVotePeriod,
 		PluginDIRs:   []string{caxPlugDir, caxPlugDir, caxPlugDir, caxPlugDir},
 	}

--- a/e2e_test/helpers.go
+++ b/e2e_test/helpers.go
@@ -16,7 +16,6 @@ import (
 	"math/big"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -114,7 +113,6 @@ type Oracle struct {
 	PluginConf string
 	Host       string
 	Command    *exec.Cmd
-	Symbols    string
 }
 
 // Start starts the process and wait until it exists, the caller should use a go routine to invoke it.
@@ -135,7 +133,6 @@ func (o *Oracle) Stop() {
 func (o *Oracle) GenCMD(wsEndpoint string) {
 	c := exec.Command("./autoracle",
 		fmt.Sprintf("-ws=%s", wsEndpoint),
-		fmt.Sprintf("-symbols=%s", o.Symbols),
 		fmt.Sprintf("-key.file=%s", o.Key.KeyFile),
 		fmt.Sprintf("-key.password=%s", o.Key.Password),
 		fmt.Sprintf("-plugin.dir=%s", o.PluginDir),
@@ -201,7 +198,7 @@ func (n *L1Node) Stop() {
 
 type NetworkConfig struct {
 	EnableL1Logs    bool
-	Symbols         string
+	Symbols         []string
 	VotePeriod      uint64
 	PluginDIRs      []string // different oracle can have different plugins configured.
 	SimulateTimeout int      // to simulate timeout in seconds at data source simulator when processing http request.
@@ -215,7 +212,7 @@ type Network struct {
 	L1Nodes      []*L1Node
 	L2Nodes      []*Oracle
 	Simulator    *DataSimulator
-	Symbols      string
+	Symbols      []string
 	VotePeriod   uint64
 	PluginDirs   []string // different oracle can have different plugins configured.
 	PluginConf   []string // different oracle can have different plugin conf.
@@ -343,7 +340,6 @@ func configNetwork(network *Network, freeKeys []*Key, freePorts []int, nodes int
 			PluginDir:  network.PluginDirs[i],
 			PluginConf: network.PluginConf[i],
 			Host:       defaultHost,
-			Symbols:    network.Symbols,
 		}
 
 		// allocate a key and 2 ports for l1 validator client,
@@ -397,7 +393,7 @@ func makeGenesisConfig(srcTemplate string, dstFile string, vals []*Validator, ne
 	genesis.Config.Autonity.Treasury = net.TreasuryKey.Key.Address
 	genesis.Config.Autonity.Validators = append(genesis.Config.Autonity.Validators, vals...)
 
-	genesis.Config.OracleContractConfig.Symbols = strings.Split(net.Symbols, ",")
+	genesis.Config.OracleContractConfig.Symbols = net.Symbols
 	genesis.Config.OracleContractConfig.VotePeriod = net.VotePeriod
 
 	jsonData, err := json.MarshalIndent(genesis, "", " ")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil" //nolint
 	"os"
 	"sort"
-	"strings"
 )
 
 var (
@@ -53,19 +52,6 @@ func ResolveSimulatedPrice(s string) decimal.Decimal {
 		defaultPrice = pNTNUSD
 	}
 	return defaultPrice
-}
-
-func ParseSymbols(symbols string) []string {
-	var symbolArray []string
-	syms := strings.Split(symbols, ",")
-	for _, s := range syms {
-		symbol := strings.TrimSpace(s)
-		if len(symbol) == 0 {
-			continue
-		}
-		symbolArray = append(symbolArray, symbol)
-	}
-	return symbolArray
 }
 
 func ParsePlaybookHeader(playbook string) ([]string, error) {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -7,19 +7,6 @@ import (
 	"testing"
 )
 
-func TestParseSymbols(t *testing.T) {
-	defaultSymbols := "ETH-USDC,ETH-USDT,ETH-BTC"
-	symbolsWithSpace := " ETH-USDC , ETH-USDT, ETH-BTC "
-	outputSymbols := ParseSymbols(defaultSymbols)
-	require.Equal(t, 3, len(outputSymbols))
-	require.Equal(t, "ETH-USDC", outputSymbols[0])
-	require.Equal(t, "ETH-USDT", outputSymbols[1])
-	require.Equal(t, "ETH-BTC", outputSymbols[2])
-
-	results := ParseSymbols(symbolsWithSpace)
-	require.Equal(t, outputSymbols, results)
-}
-
 func TestParsePlaybookHeader(t *testing.T) {
 	playbook := "../test_data/samplePlaybook.csv"
 	symbols, err := ParsePlaybookHeader(playbook)

--- a/main.go
+++ b/main.go
@@ -9,15 +9,14 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 )
 
 func main() { //nolint
 	conf := config.MakeConfig()
-	log.Printf("\n\n\n \tRunning autonity oracle server %s\n\twith symbols: %s\n\tand plugin directory: %s\n "+
+	log.Printf("\n\n\n \tRunning autonity oracle server %s\n\twith plugin directory: %s\n "+
 		"\tby connecting to L1 node: %s\n \ton oracle contract address: %s \n\n\n",
-		config.Version, strings.Join(conf.Symbols, ","), conf.PluginDIR, conf.AutonityWSUrl, types.OracleContractAddress)
+		config.Version, conf.PluginDIR, conf.AutonityWSUrl, types.OracleContractAddress)
 
 	dialer := &types.L1Dialer{}
 	client, err := dialer.Dial(conf.AutonityWSUrl)

--- a/oracle_server/oracle_server.go
+++ b/oracle_server/oracle_server.go
@@ -87,7 +87,6 @@ func NewOracleServer(conf *types.OracleServiceConfig, dialer types.Dialer, clien
 		key:            conf.Key,
 		gasTipCap:      conf.GasTipCap,
 		pluginConfFile: conf.PluginConfFile,
-		symbols:        conf.Symbols,
 		pluginDIR:      conf.PluginDIR,
 		pluginSet:      make(map[string]*pWrapper.PluginWrapper),
 		doneCh:         make(chan struct{}),

--- a/oracle_server/oracle_server_test.go
+++ b/oracle_server/oracle_server_test.go
@@ -42,7 +42,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -51,7 +51,7 @@ func TestOracleServer(t *testing.T) {
 
 		srv := NewOracleServer(conf, dialerMock, l1Mock, contractMock)
 		require.Equal(t, currentRound.Uint64(), srv.curRound)
-		require.Equal(t, conf.Symbols, srv.symbols)
+		require.Equal(t, config.DefaultSymbols, srv.symbols)
 		require.Equal(t, true, srv.pricePrecision.Equal(decimal.NewFromInt(precision.Int64())))
 		require.Equal(t, votePeriod.Uint64(), srv.votePeriod)
 		require.Equal(t, 1, len(srv.pluginSet))
@@ -66,7 +66,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -87,7 +87,7 @@ func TestOracleServer(t *testing.T) {
 		}
 
 		target := ts + 15
-		for _, s := range conf.Symbols {
+		for _, s := range config.DefaultSymbols {
 			p, err := srv.aggregatePrice(s, target)
 			require.NoError(t, err)
 			require.Equal(t, true, p.Price.Equal(helpers.ResolveSimulatedPrice(s)))
@@ -95,7 +95,7 @@ func TestOracleServer(t *testing.T) {
 
 		// gc data samples
 		srv.gcDataSamples()
-		for _, s := range conf.Symbols {
+		for _, s := range config.DefaultSymbols {
 			_, err := srv.aggregatePrice(s, target)
 			require.Error(t, err)
 		}
@@ -120,7 +120,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).AnyTimes().Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).AnyTimes().Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -142,7 +142,7 @@ func TestOracleServer(t *testing.T) {
 
 		// prepare last round data.
 		prices := make(types.PriceBySymbol)
-		for _, s := range conf.Symbols {
+		for _, s := range config.DefaultSymbols {
 			prices[s] = types.Price{
 				Timestamp: 0,
 				Symbol:    s,
@@ -152,7 +152,7 @@ func TestOracleServer(t *testing.T) {
 		seed := time.Now().UnixNano()
 		roundData := &types.RoundData{
 			RoundID:        srv.curRound,
-			Symbols:        conf.Symbols,
+			Symbols:        config.DefaultSymbols,
 			Salt:           new(big.Int).SetUint64(rand.New(rand.NewSource(seed)).Uint64()), // nolint
 			CommitmentHash: common.Hash{},
 			Prices:         prices,
@@ -180,8 +180,8 @@ func TestOracleServer(t *testing.T) {
 		require.Equal(t, 2, len(srv.roundData))
 		require.Equal(t, srv.curRound, srv.roundData[srv.curRound].RoundID)
 		require.Equal(t, tx.Hash(), srv.roundData[srv.curRound].Tx.Hash())
-		require.Equal(t, conf.Symbols, srv.roundData[srv.curRound].Symbols)
-		require.Equal(t, srv.commitmentHash(srv.roundData[srv.curRound], conf.Symbols), srv.roundData[srv.curRound].CommitmentHash)
+		require.Equal(t, config.DefaultSymbols, srv.roundData[srv.curRound].Symbols)
+		require.Equal(t, srv.commitmentHash(srv.roundData[srv.curRound], config.DefaultSymbols), srv.roundData[srv.curRound].CommitmentHash)
 
 		srv.pluginSet["template_plugin"].Close()
 	})
@@ -193,7 +193,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -202,12 +202,12 @@ func TestOracleServer(t *testing.T) {
 
 		srv := NewOracleServer(conf, dialerMock, l1Mock, contractMock)
 		require.Equal(t, currentRound.Uint64(), srv.curRound)
-		require.Equal(t, conf.Symbols, srv.symbols)
+		require.Equal(t, config.DefaultSymbols, srv.symbols)
 		require.Equal(t, true, srv.pricePrecision.Equal(decimal.NewFromInt(precision.Int64())))
 		require.Equal(t, votePeriod.Uint64(), srv.votePeriod)
 		require.Equal(t, 1, len(srv.pluginSet))
 
-		nSymbols := append(conf.Symbols, "NTNETH", "NTNBTC", "NTNCNY")
+		nSymbols := append(config.DefaultSymbols, "NTNETH", "NTNBTC", "NTNCNY")
 		srv.handleNewSymbolsEvent(nSymbols)
 		require.Equal(t, len(nSymbols), len(srv.symbols))
 		require.Equal(t, nSymbols, srv.symbols)
@@ -221,7 +221,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -230,7 +230,7 @@ func TestOracleServer(t *testing.T) {
 
 		srv := NewOracleServer(conf, dialerMock, l1Mock, contractMock)
 		require.Equal(t, currentRound.Uint64(), srv.curRound)
-		require.Equal(t, conf.Symbols, srv.symbols)
+		require.Equal(t, config.DefaultSymbols, srv.symbols)
 		require.Equal(t, true, srv.pricePrecision.Equal(decimal.NewFromInt(precision.Int64())))
 		require.Equal(t, votePeriod.Uint64(), srv.votePeriod)
 		require.Equal(t, 1, len(srv.pluginSet))
@@ -260,7 +260,7 @@ func TestOracleServer(t *testing.T) {
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
-		contractMock.EXPECT().GetSymbols(nil).Return(conf.Symbols, nil)
+		contractMock.EXPECT().GetSymbols(nil).Return(config.DefaultSymbols, nil)
 		contractMock.EXPECT().GetPrecision(nil).Return(precision, nil)
 		contractMock.EXPECT().GetVotePeriod(nil).Return(votePeriod, nil)
 		contractMock.EXPECT().WatchNewRound(gomock.Any(), gomock.Any()).Return(subRoundEvent, nil)
@@ -269,7 +269,7 @@ func TestOracleServer(t *testing.T) {
 
 		srv := NewOracleServer(conf, dialerMock, l1Mock, contractMock)
 		require.Equal(t, currentRound.Uint64(), srv.curRound)
-		require.Equal(t, conf.Symbols, srv.symbols)
+		require.Equal(t, config.DefaultSymbols, srv.symbols)
 		require.Equal(t, true, srv.pricePrecision.Equal(decimal.NewFromInt(precision.Int64())))
 		require.Equal(t, votePeriod.Uint64(), srv.votePeriod)
 		require.Equal(t, 1, len(srv.pluginSet))

--- a/types/types.go
+++ b/types/types.go
@@ -14,7 +14,6 @@ import (
 )
 
 var (
-	EnvSymbols              = "SYMBOLS"
 	EnvPluginDIR            = "PLUGIN_DIR"
 	EnvKeyFile              = "KEY_FILE"
 	EnvKeyFilePASS          = "KEY_PASSWORD"
@@ -64,7 +63,6 @@ type OracleServiceConfig struct {
 	GasTipCap      uint64
 	Key            *keystore.Key
 	AutonityWSUrl  string
-	Symbols        []string
 	PluginDIR      string
 	PluginConfFile string
 }


### PR DESCRIPTION
To close #7 #9 and add make task for Bakerloo network. This PR contains:
- the removal of the flag and system environment variable of symbols
- a build task in Makefile to make simulator service and its plugin for Bakerloo network.




