### PR TITLE
fix plugins-conf.yml plugin name

### DIFF
--- a/config/plugins-conf.yml
+++ b/config/plugins-conf.yml
@@ -35,7 +35,7 @@
 #  - name: forex_currencyfreaks              # required, it is the plugin file name in the plugin directory.
 #    key: 175aab9e47e54790bf6d502c48407c10   # required, visit https://currencyfreaks.com to get your key, and replace it.
 
-#  - name: forex_openexchangerate            # required, it is the plugin file name in the plugin directory.
+#  - name: forex_openexchange                # required, it is the plugin file name in the plugin directory.
 #    key: 1be02ca33c4843ee968c4cedd2686f01   # required, visit https://openexchangerates.org to get your key, and replace it.
 
 #  - name: forex_currencylayer               # required, it is the plugin file name in the plugin directory.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your submission pass tests?
* [x] Have you lint your code locally prior to submission?


I ran into a snag while setting up the oracle and saw it's because the plugin name is different 

![image](https://github.com/autonity/autonity-oracle/assets/117326984/84019c60-0aeb-41bc-b31e-32c29b318255)


