### PR TITLE
feature, do not launch plugins of missing required key.

### DIFF
--- a/oracle_server/oracle_server.go
+++ b/oracle_server/oracle_server.go
@@ -28,7 +28,7 @@ import (
 var (
 	TenSecsInterval  = 10 * time.Second // 10s ticker job to check health with l1, plugin discovery and regular data sampling.
 	OneSecInterval   = 1 * time.Second  // 1s ticker job to check if we need to do pre-sampling.
-	PreSamplingRange = 15               // pre-sampling starts in 15blocks in advance.
+	PreSamplingRange = 5                // pre-sampling starts in 5 blocks in advance.
 	SaltRange        = new(big.Int).SetUint64(math.MaxInt64)
 	AlertBalance     = new(big.Int).SetUint64(2000000000000) // 2000 Gwei, 0.000002 Ether
 )
@@ -43,6 +43,8 @@ type OracleServer struct {
 	pluginDIR string                             // the dir saves the plugins.
 	pluginSet map[string]*pWrapper.PluginWrapper // the plugin clients that connect with different adapters.
 	symbols   []string                           // the symbols for data fetching in oracle service.
+
+	keyRequiredPlugins map[string]struct{} // saving those plugins which require a key granted by data provider
 
 	// the reporting staffs
 	dialer         types.Dialer
@@ -79,20 +81,21 @@ type OracleServer struct {
 func NewOracleServer(conf *types.OracleServiceConfig, dialer types.Dialer, client types.Blockchain,
 	oc contract.ContractAPI) *OracleServer {
 	os := &OracleServer{
-		dialer:         dialer,
-		client:         client,
-		oracleContract: oc,
-		l1WSUrl:        conf.AutonityWSUrl,
-		roundData:      make(map[uint64]*types.RoundData),
-		key:            conf.Key,
-		gasTipCap:      conf.GasTipCap,
-		pluginConfFile: conf.PluginConfFile,
-		pluginDIR:      conf.PluginDIR,
-		pluginSet:      make(map[string]*pWrapper.PluginWrapper),
-		doneCh:         make(chan struct{}),
-		regularTicker:  time.NewTicker(TenSecsInterval),
-		psTicker:       time.NewTicker(OneSecInterval),
-		loggingLevel:   conf.LoggingLevel,
+		dialer:             dialer,
+		client:             client,
+		oracleContract:     oc,
+		l1WSUrl:            conf.AutonityWSUrl,
+		roundData:          make(map[uint64]*types.RoundData),
+		key:                conf.Key,
+		gasTipCap:          conf.GasTipCap,
+		pluginConfFile:     conf.PluginConfFile,
+		pluginDIR:          conf.PluginDIR,
+		pluginSet:          make(map[string]*pWrapper.PluginWrapper),
+		keyRequiredPlugins: make(map[string]struct{}),
+		doneCh:             make(chan struct{}),
+		regularTicker:      time.NewTicker(TenSecsInterval),
+		psTicker:           time.NewTicker(OneSecInterval),
+		loggingLevel:       conf.LoggingLevel,
 	}
 
 	os.logger = hclog.New(&hclog.LoggerOptions{
@@ -120,7 +123,7 @@ func NewOracleServer(conf *types.OracleServiceConfig, dialer types.Dialer, clien
 	for _, file := range binaries {
 		f := file
 		pConf := plugConfs[f.Name()]
-		os.tryLoadingNewPlugin(f, pConf)
+		os.loadNewPlugin(f, pConf)
 	}
 
 	os.logger.Info("Running oracle contract listener at", "WS", conf.AutonityWSUrl, "ID", conf.Key.Address.String())
@@ -658,54 +661,69 @@ func (os *OracleServer) PluginRuntimeDiscovery() {
 	for _, file := range binaries {
 		f := file
 		pConf := plugConfs[f.Name()]
-		os.tryLoadingNewPlugin(f, pConf)
+
+		// skip to set up plugins until there is a service key is presented at plugin-confs.yml
+		if _, ok := os.keyRequiredPlugins[f.Name()]; ok && pConf.Key == "" {
+			continue
+		}
+
+		os.loadNewPlugin(f, pConf)
 	}
 }
 
-func (os *OracleServer) tryLoadingNewPlugin(f fs.FileInfo, plugConf types.PluginConfig) {
+func (os *OracleServer) loadNewPlugin(f fs.FileInfo, plugConf types.PluginConfig) {
 	plugin, ok := os.pluginSet[f.Name()]
 	if !ok {
 		os.logger.Info("** New plugin discovered, going to setup it: ", f.Name(), f.Mode().String())
-
-		if err := os.ApplyPluginConf(f.Name(), plugConf); err != nil {
-			os.logger.Error("Apply plugin config", "error", err.Error())
+		pluginWrapper, err := os.setupNewPlugin(f.Name(), &plugConf)
+		if err != nil {
 			return
 		}
 
-		pluginWrapper := pWrapper.NewPluginWrapper(os.loggingLevel, f.Name(), os.pluginDIR, os)
-		if err := pluginWrapper.Initialize(); err != nil {
-			os.logger.Error("Cannot initialize plugin", "name", f.Name(), "error", err.Error())
-			return
-		}
 		os.pluginSet[f.Name()] = pluginWrapper
 		return
 	}
 
 	if f.ModTime().After(plugin.StartTime()) || plugin.Exited() {
-		if err := os.ApplyPluginConf(f.Name(), plugConf); err != nil {
-			os.logger.Error("Apply plugin config", "error", err.Error())
-			return
-		}
-
 		os.logger.Info("** Replacing legacy plugin with new one: ", f.Name(), f.Mode().String())
 		// stop the legacy plugin
 		plugin.Close()
 		delete(os.pluginSet, f.Name())
 
-		pluginWrapper := pWrapper.NewPluginWrapper(os.loggingLevel, f.Name(), os.pluginDIR, os)
-		if err := pluginWrapper.Initialize(); err != nil {
-			os.logger.Error("Cannot initialize plugin", "name", f.Name(), "error", err.Error())
+		pluginWrapper, err := os.setupNewPlugin(f.Name(), &plugConf)
+		if err != nil {
 			return
 		}
 		os.pluginSet[f.Name()] = pluginWrapper
 	}
+}
+
+func (os *OracleServer) setupNewPlugin(name string, conf *types.PluginConfig) (*pWrapper.PluginWrapper, error) {
+	if err := os.ApplyPluginConf(name, conf); err != nil {
+		os.logger.Error("Apply plugin config", "error", err.Error())
+		return nil, err
+	}
+
+	pluginWrapper := pWrapper.NewPluginWrapper(os.loggingLevel, name, os.pluginDIR, os, conf)
+	if err := pluginWrapper.Initialize(); err != nil {
+		// if the plugin states that a service key is missing, then we mark it down, thus the runtime discovery can
+		// skip those plugins without a key configured.
+		if err == types.ErrMissingServiceKey {
+			os.keyRequiredPlugins[name] = struct{}{}
+		}
+		os.logger.Error("Cannot setup plugin", "name", name, "error", err.Error())
+		pluginWrapper.CleanPluginProcess()
+		return nil, err
+	}
+
+	return pluginWrapper, nil
 }
 
 func (os *OracleServer) WatchSampleEvent(sink chan<- *types.SampleEvent) event.Subscription {
 	return os.sampleEventFee.Subscribe(sink)
 }
 
-func (os *OracleServer) ApplyPluginConf(name string, plugConf types.PluginConfig) error {
+func (os *OracleServer) ApplyPluginConf(name string, plugConf *types.PluginConfig) error {
 	// set the plugin configuration via system env, thus the plugin can load it on startup.
 	conf, err := json.Marshal(plugConf)
 	if err != nil {

--- a/oracle_server/oracle_server_test.go
+++ b/oracle_server/oracle_server_test.go
@@ -23,6 +23,12 @@ import (
 	"time"
 )
 
+func TestExample(t *testing.T) {
+	mapping := make(map[int]int)
+	mapping[1] = 1
+	require.Equal(t, 0, mapping[2])
+}
+
 func TestOracleServer(t *testing.T) {
 	currentRound := new(big.Int).SetUint64(1)
 	precision := new(big.Int).SetUint64(10000000)
@@ -62,7 +68,7 @@ func TestOracleServer(t *testing.T) {
 	t.Run("test pre-sampling happy case", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		chainHeight := uint64(46)
+		chainHeight := uint64(56)
 		dialerMock := mock.NewMockDialer(ctrl)
 		contractMock := cMock.NewMockContractAPI(ctrl)
 		contractMock.EXPECT().GetRound(nil).Return(currentRound, nil)
@@ -106,7 +112,7 @@ func TestOracleServer(t *testing.T) {
 	t.Run("test round vote happy case, with commitment and round data", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		chainHeight := uint64(45)
+		chainHeight := uint64(55)
 
 		var voters []common.Address
 		voters = append(voters, conf.Key.Address)

--- a/plugins/binance/binance.go
+++ b/plugins/binance/binance.go
@@ -46,6 +46,10 @@ func NewBIClient(conf *types.PluginConfig) *BIClient {
 	return &BIClient{conf: conf, client: client, logger: logger}
 }
 
+func (bi *BIClient) KeyRequired() bool {
+	return false
+}
+
 func (bi *BIClient) FetchPrice(symbols []string) (common.Prices, error) {
 	var prices common.Prices
 	u, err := bi.buildURL(symbols)

--- a/plugins/common/client.go
+++ b/plugins/common/client.go
@@ -14,6 +14,7 @@ type Connection interface {
 type DataSourceClient interface {
 	AvailableSymbols() ([]string, error)
 	FetchPrice([]string) (Prices, error)
+	KeyRequired() bool
 	Close()
 }
 

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -129,7 +129,7 @@ func (p *Plugin) State() (types.PluginState, error) {
 
 	state.Version = p.version
 	state.AvailableSymbols = symbols
-
+	state.KeyRequired = p.client.KeyRequired()
 	return state, nil
 }
 

--- a/plugins/forex_currencyfreaks/forex_currencyfreaks.go
+++ b/plugins/forex_currencyfreaks/forex_currencyfreaks.go
@@ -21,7 +21,7 @@ const (
 )
 
 var defaultConfig = types.PluginConfig{
-	Key:                "575aab9e47e54790bf6d502c48407c10",
+	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "api.currencyfreaks.com",
 	Timeout:            10, //10s
@@ -62,6 +62,10 @@ func NewCFClient(conf *types.PluginConfig) *CFClient {
 	})
 
 	return &CFClient{conf: conf, client: client, logger: logger}
+}
+
+func (cf *CFClient) KeyRequired() bool {
+	return true
 }
 
 func (cf *CFClient) FetchPrice(symbols []string) (common.Prices, error) {

--- a/plugins/forex_currencylayer/forex_currencylayer.go
+++ b/plugins/forex_currencylayer/forex_currencylayer.go
@@ -21,7 +21,7 @@ const (
 )
 
 var defaultConfig = types.PluginConfig{
-	Key:                "705af082ac7f7d150c87303d4e2f049e",
+	Key:                "",
 	Scheme:             "http", // todo: replace the scheme with https once we purchase the service plan.
 	Endpoint:           "api.currencylayer.com",
 	Timeout:            10, //10s
@@ -65,6 +65,10 @@ func NewCLClient(conf *types.PluginConfig) *CLClient {
 	})
 
 	return &CLClient{conf: conf, client: client, logger: logger}
+}
+
+func (cl *CLClient) KeyRequired() bool {
+	return true
 }
 
 func (cl *CLClient) FetchPrice(symbols []string) (common.Prices, error) {

--- a/plugins/forex_exchangerate/forex_exchangerate.go
+++ b/plugins/forex_exchangerate/forex_exchangerate.go
@@ -20,7 +20,7 @@ const (
 )
 
 var defaultConfig = types.PluginConfig{
-	Key:                "411f04e4775bb86c20296530",
+	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "v6.exchangerate-api.com",
 	Timeout:            10, //10s
@@ -67,6 +67,10 @@ func NewEXClient(conf *types.PluginConfig) *EXClient {
 	})
 
 	return &EXClient{conf: conf, client: client, logger: logger}
+}
+
+func (ex *EXClient) KeyRequired() bool {
+	return true
 }
 
 func (ex *EXClient) FetchPrice(symbols []string) (common.Prices, error) {

--- a/plugins/forex_openexchange/forex_openexchange.go
+++ b/plugins/forex_openexchange/forex_openexchange.go
@@ -22,7 +22,7 @@ const (
 )
 
 var defaultConfig = types.PluginConfig{
-	Key:                "0be02ca33c4843ee968c4cedd2686f01",
+	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "openexchangerates.org",
 	Timeout:            10, //10s
@@ -68,6 +68,10 @@ func NewOXClient(conf *types.PluginConfig) *OXClient {
 		client: client,
 		logger: logger,
 	}
+}
+
+func (oe *OXClient) KeyRequired() bool {
+	return true
 }
 
 func (oe *OXClient) FetchPrice(symbols []string) (common.Prices, error) {

--- a/plugins/pcgc_cax/pcgc_cax.go
+++ b/plugins/pcgc_cax/pcgc_cax.go
@@ -69,6 +69,10 @@ func NewCAXClient(conf *types.PluginConfig) *CAXClient {
 	}
 }
 
+func (cc *CAXClient) KeyRequired() bool {
+	return false
+}
+
 func (cc *CAXClient) FetchPrice(symbols []string) (common.Prices, error) {
 	var prices common.Prices
 	priceMap := make(map[string]common.Price)

--- a/plugins/simulator_plugin/simulator_plugin.go
+++ b/plugins/simulator_plugin/simulator_plugin.go
@@ -47,6 +47,10 @@ func NewSIMClient(conf *types.PluginConfig) *SIMClient {
 	return &SIMClient{conf: conf, client: client, logger: logger}
 }
 
+func (bi *SIMClient) KeyRequired() bool {
+	return false
+}
+
 func (bi *SIMClient) FetchPrice(symbols []string) (common.Prices, error) {
 	var prices common.Prices
 	u, err := bi.buildURL(symbols)

--- a/plugins/template_plugin/template_plugin.go
+++ b/plugins/template_plugin/template_plugin.go
@@ -122,6 +122,7 @@ func (g *TemplatePlugin) State() (types.PluginState, error) {
 		}
 	}
 
+	state.KeyRequired = g.client.KeyRequired()
 	state.Version = g.version
 	state.AvailableSymbols = symbols
 
@@ -192,6 +193,11 @@ func NewTemplateClient(conf *types.PluginConfig) *TemplateClient {
 	})
 
 	return &TemplateClient{conf: conf, client: client, logger: logger}
+}
+
+// KeyRequired returns true if the service key is required to access the data source.
+func (tc *TemplateClient) KeyRequired() bool {
+	return false
 }
 
 // FetchPrice is the function fetch prices of the available symbols from data vendor.

--- a/types/plugin_spec.go
+++ b/types/plugin_spec.go
@@ -28,6 +28,7 @@ type PluginPriceReport struct {
 // PluginState is the returned data when the oracle host want to initialise the plugin with basic information: version,
 // and available symbols that the data source support.
 type PluginState struct {
+	KeyRequired      bool
 	Version          string
 	AvailableSymbols []string
 }

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,7 @@ var (
 	ErrNoAvailablePrice  = errors.New("no available prices collected yet")
 	ErrNoDataRound       = errors.New("no data collected at current round")
 	ErrNoSymbolsObserved = errors.New("no symbols observed from oracle contract")
+	ErrMissingServiceKey = errors.New("the key to access data source is missing, please check the plugin config")
 )
 
 // MaxBufferedRounds is the number of round data to be buffered.


### PR DESCRIPTION
To close #14 , this PR contains a feature that not start those plugins which miss a required key from the plugin-confs.yml.
The changes are:
- Introduce new field (KeyRequired) in the plugin's statement interface.
- By according to the statement of a plugin, the oracle server decide to launch it or to drop it from discovery routine.  

