### PR TITLE
logging refine and adding configuration file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ LATEST_COMMIT ?= $(shell git log -n 1 master --pretty=format:"%H")
 ifeq ($(LATEST_COMMIT),)
 LATEST_COMMIT := $(shell git log -n 1 HEAD~1 --pretty=format:"%H")
 endif
+#//todo(Jason) copy the template oracle-server.config file to build-bin
 
 mkdir:
 	mkdir -p $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 
 SOLC_VERSION = 0.8.2
 BIN_DIR = ./build/bin
-CONF_FILE = ./config/plugins-conf.yml
+CONF_FILE = ./config/oracle-server.config
+PLUGIN_CONF_FILE = ./config/plugins-conf.yml
 E2E_TEST_DIR = ./e2e_test
 E2E_TEST_PLUGIN_DIR = $(E2E_TEST_DIR)/plugins
 E2E_TEST_TEMPLATE_PLUGIN_DIR = $(E2E_TEST_PLUGIN_DIR)/template_plugins
@@ -26,7 +27,6 @@ LATEST_COMMIT ?= $(shell git log -n 1 master --pretty=format:"%H")
 ifeq ($(LATEST_COMMIT),)
 LATEST_COMMIT := $(shell git log -n 1 HEAD~1 --pretty=format:"%H")
 endif
-#//todo(Jason) copy the template oracle-server.config file to build-bin
 
 mkdir:
 	mkdir -p $(BIN_DIR)
@@ -48,6 +48,8 @@ oracle-server:
 
 conf-file:
 	# copy example plugin-conf
+	cp $(PLUGIN_CONF_FILE) $(BIN_DIR)
+	# copy example oracle-server.conf
 	cp $(CONF_FILE) $(BIN_DIR)
 
 e2e-test-stuffs:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $./autoracle version
 v0.1.3
 ```
 
+// todo: (Jason) update with new config for oracle-server.config
 ## Configuration
 Values that can be configured by using environment variables:
 

--- a/README.md
+++ b/README.md
@@ -39,31 +39,60 @@ Print the version of the oracle server:
 
 ```
 $./autoracle version
-v0.1.3
+v0.1.5
 ```
 
-// todo: (Jason) update with new config for oracle-server.config
-## Configuration
-Values that can be configured by using environment variables:
+## Configuration of oracle server
+There are three ways to config oracle server.
+### Oracle Server Configuration File
+A template configuration file `oracle-server.config` is made in the build bin when you build the project, and it is also
+included in the release package, you can config and start the oracle server with it:
+```shell
+#This is a configuration file for autonity-oracle server.
+#Set the gas priority fee cap to issue the oracle data report transactions.
+tip 1
+#Set oracle server key file
+key.file ./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe
+#Set the password to decrypt oracle server key file
+key.password 123%&%^$
+#Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error
+log.level 3
+#Set the WS-RPC server listening interface and port of the connected Autonity Client node
+ws ws://127.0.0.1:8546
+#Set the directory of the data plugins.
+plugin.dir ./plugins
+#Set the plugins' configuration file
+plugin.conf ./plugins-conf.yml
+```
+Start oracle server with a config file:
+```shell
+$./autoracle --config="./oracle-server.config"
+```
+
+### System Environment Variables
+A set of system environment variables can be used too to config oracle server:
 
 | **Env Variable** | **Required?** | **Meaning** | **Default Value**                                                                                    | **Valid Options** |
 |----------------------------|---------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `PLUGIN_DIR` | No | The directory that stores the plugins | "./plugins"                                                                                | any directory that saves plugins |
+| `PLUGIN_DIR` | Yes | The directory that stores the plugins | "./plugins"                                                                                | any directory that saves plugins |
 | `KEY_FILE` | Yes | The encrypted key file path that contains the private key of the oracle client. | "./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" | any key file that saves the private key |
 | `KEY_PASSWORD` | Yes | The password of the key file that contains the private key of the oracle client. | "123"                                                                                                | any password that encrypted the private key |
 | `AUTONITY_WS` | Yes | The web socket RPC URL of your Autonity L1 Node that the oracle client communicates with. | "ws://127.0.0.1:8546"                                                                                | the web socket rpc endpoint url of the Autonity client. |
 | `PLUGIN_CONF` | Yes | The plugins' configuration file in YAML. | "./plugins-conf.yml"                                                               | the configuration file of the oracle plugins. |
+| `CONFIG` | No | Use a configuration file to start oracle server. | ""                                                               | the configuration file of the oracle server. |
 | `GAS_TIP_CAP` | No | The gas priority fee cap to issue the oracle data report transactions | 1                                                               | A non-zero value per gas to prioritize your data report TX to be mined. |
 | `LOG_LEVEL` | No | The logging level of the oracle server | 3                                                              | available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error. |
 
 
-or by using console flags:
+### CLI Flags
+A set of CLI flags can be used too to config and start oracle server:
 ```shell
 $./autoracle --help
 Usage of Autonity Oracle Server:
 Sub commands: 
   version: print the version of the oracle server.
 Flags:
+  -config="": Set the oracle server configuration file path.
   -key.file="./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe": Set oracle server key file
   -key.password="123": Set the password to decrypt oracle server key file
   -log.level=2: Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error
@@ -74,13 +103,12 @@ Flags:
 
 ```
 
-
 example to run the autonity oracle service with console flags:
 ```shell
 $./autoracle --plugin.dir="./plugins" --key.file="../../test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546" --plugin.conf="./plugins-conf.yml"
 ```
-plugin configuration file:    
-
+## Configuration of plugins:
+The configuration of plugins are assembled in a yaml file:
 `A yaml file to config plugins:`
 
 ```yaml
@@ -175,7 +203,6 @@ Path of the secret key file: key-data/keystore/UTC--2023-02-28T11-40-15.38370976
 Prepare the plugin binaries, and save them into the `plugins` directory. To start the service, set the system environment variables and run the binary:
 ```shell
 
-$export SYMBOLS="AUD-USD,CAD-USD,EUR-USD,GBP-USD,JPY-USD,SEK-USD,ATN-USD,NTN-USD,NTN-ATN"
 $export PLUGIN_DIR="./plugins"
 $export KEY_FILE="./test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe"
 $export KEY_PASSWORD="your passord to the key file"
@@ -184,10 +211,14 @@ $export PLUGIN_CONF="./plugins-conf.yml"
 $.~/src/autonity-oracle/build/bin/autoracle
 ```
 
-or configure by using console flags and run the binary:
+or configure it by using console flags and run the binary:
 
 ```shell
 $./autoracle --plugin.dir="./plugins" --key.file="./test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe" --key.password="123" --ws="ws://127.0.0.1:8546"
+```
+or configure it by a configuration file: `oracle-server.config`:
+```shell
+$./autoracle --config="./oracle-server.config"
 ```
 
 ### Deploy via linux system daemon

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ var (
 	DefaultSymbols        = []string{"AUD-USD", "CAD-USD", "EUR-USD", "GBP-USD", "JPY-USD", "SEK-USD", "ATN-USD", "NTN-USD", "NTN-ATN"}
 )
 
-const Version = "v0.1.5"
+const Version = "v0.1.6"
 const UsageOracleKey = "Set the oracle server key file path."
 const UsagePluginConf = "Set the plugin's configuration file path."
 const UsageOracleConf = "Set the oracle server configuration file path."

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,22 +9,35 @@ import (
 	"testing"
 )
 
-func TestMakeConfigWithConfiguration(t *testing.T) {
+func TestMakeConfigWithEnvironmentVariables(t *testing.T) {
 	t.Run("config set by system environment variable", func(t *testing.T) {
 		err := os.Setenv(types.EnvKeyFile, "../test_data/keystore/UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvKeyFile)
+
 		err = os.Setenv(types.EnvKeyFilePASS, "123")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvKeyFilePASS)
+
 		err = os.Setenv(types.EnvPluginDIR, "./")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvPluginDIR)
+
 		err = os.Setenv(types.EnvLogLevel, "3")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvLogLevel)
+
 		err = os.Setenv(types.EnvGasTipCap, "30")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvGasTipCap)
+
 		err = os.Setenv(types.EnvWS, "ws://127.0.0.1:30303")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvWS)
+
 		err = os.Setenv(types.EnvPluginCof, "./plugin-conf.yml")
 		require.NoError(t, err)
+		defer os.Unsetenv(types.EnvPluginCof)
 
 		conf := MakeConfig()
 		require.Equal(t, "./", conf.PluginDIR)

--- a/config/oracle-server.config
+++ b/config/oracle-server.config
@@ -2,15 +2,21 @@
 
 #Set the gas priority fee cap to issue the oracle data report transactions.
 tip 1
-#Set oracle server key file
+
+#Set oracle server key file.
 key.file ./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe
-#Set the password to decrypt oracle server key file
+
+#Set the password to decrypt oracle server key file.
 key.password 123%&%^$
-#Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error
+
+#Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error.
 log.level 3
-#Set the WS-RPC server listening interface and port of the connected Autonity Client node
+
+#Set the WS-RPC server listening interface and port of the connected Autonity Client node.
 ws ws://127.0.0.1:8546
+
 #Set the directory of the data plugins.
 plugin.dir ./plugins
-#Set the plugins' configuration file
+
+#Set the plugins' configuration file.
 plugin.conf ./plugins-conf.yml

--- a/config/oracle-server.config
+++ b/config/oracle-server.config
@@ -1,9 +1,16 @@
 # this is a configuration file for autonity-oracle server.
 
+#Set the gas priority fee cap to issue the oracle data report transactions.
 tip 1
+#Set oracle server key file
 key.file ./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe
-key.password 123
+#Set the password to decrypt oracle server key file
+key.password 123%&%^$
+#Set the logging level, available levels are:  0: NoLevel, 1: Trace, 2:Debug, 3: Info, 4: Warn, 5: Error
 log.level 3
+#Set the WS-RPC server listening interface and port of the connected Autonity Client node
 ws ws://127.0.0.1:8546
+#Set the directory of the data plugins.
 plugin.dir ./plugins
+#Set the plugins' configuration file
 plugin.conf ./plugins-conf.yml

--- a/config/oracle-server.config
+++ b/config/oracle-server.config
@@ -1,0 +1,9 @@
+# this is a configuration file for autonity-oracle server.
+
+tip 1
+key.file ./UTC--2023-02-27T09-10-19.592765887Z--b749d3d83376276ab4ddef2d9300fb5ce70ebafe
+key.password 123
+log.level 3
+ws ws://127.0.0.1:8546
+plugin.dir ./plugins
+plugin.conf ./plugins-conf.yml

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -49,8 +49,6 @@ func TestHappyCase(t *testing.T) {
 	testHappyCase(t, o, endRound, pricePrecision)
 }
 
-//todo: (Jason) test to start oracle server with a config file.
-
 func TestLostL1Connectivity(t *testing.T) {
 	var netConf = &NetworkConfig{
 		EnableL1Logs: false,

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -49,6 +49,8 @@ func TestHappyCase(t *testing.T) {
 	testHappyCase(t, o, endRound, pricePrecision)
 }
 
+//todo: (Jason) test to start oracle server with a config file.
+
 func TestLostL1Connectivity(t *testing.T) {
 	var netConf = &NetworkConfig{
 		EnableL1Logs: false,

--- a/oracle_server/oracle_server.go
+++ b/oracle_server/oracle_server.go
@@ -349,12 +349,12 @@ func (os *OracleServer) handleRoundVote() error {
 	// query last round's prices, its random salt which will reveal last round's report.
 	lastRoundData, ok := os.roundData[os.curRound-1]
 	if !ok {
-		os.logger.Info("cannot find last round's data, reports with commitment hash and no data")
+		os.logger.Debug("no last round data, client is no longer a voter or it will report with commitment hash")
 	}
 
 	// if node is no longer a validator, and it doesn't have last round data, skip reporting.
 	if !isVoter && !ok {
-		os.logger.Debug("skip reporting since client is no long a voter, and have no last round data.")
+		os.logger.Debug("skip data reporting since client is no longer a voter")
 		return nil
 	}
 
@@ -363,7 +363,7 @@ func (os *OracleServer) handleRoundVote() error {
 		return os.reportWithCommitment(os.curRound, lastRoundData)
 	}
 
-	// report with last round data but without current round commitment.
+	// voter reports with last round data but without current round commitment since it is not committee member now.
 	return os.reportWithoutCommitment(lastRoundData)
 }
 


### PR DESCRIPTION
- Issue #16 has been resolved by introducing an enhanced method for configuring the Oracle server using a configuration file. The previous configuration method using CLI flags and system environment variables remains fully compatible. 
- Issue #20 has been addressed by refining the logging for the non-voter case.

@yazzaoui @cmjc @vpiyush @lorenzo-dev1 @tbssajal , please review this PR. We plan to release the Oracle server alongside Autonity this week.