### PR TITLE
Remove simulator plugin, and update default data refresh interval for AMM plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ autoracle-bakerloo: mkdir oracle-server forex-plugins cex-plugins crypto_source_
 	@echo "Run \"$(BIN_DIR)/autoracle\" to launch autonity oracle for bakerloo network."
 
 # build the whole components for for piccadilly, it is default target or oracle server as main net is not planned and launched yet.
-autoracle: mkdir oracle-server forex-plugins cex-plugins amm-plugins piccadilly-sim-plugin conf-file e2e-test-stuffs
+autoracle: mkdir oracle-server forex-plugins cex-plugins amm-plugins conf-file e2e-test-stuffs
 	@echo "Done building for piccadilly network."
 	@echo "Run \"$(BIN_DIR)/autoracle\" to launch autonity oracle for piccadilly network."
 

--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,7 @@ var (
 
 // Version number of the oracle server in uint8. It is required
 // for data reporting interface to collect oracle clients version.
-const Version uint8 = 22
+const Version uint8 = 23
 
 // OracleDecimals describe the price precision in oracle protocol,
 // it is a fixed number in oracle contract.

--- a/plugins/crypto_uniswap/crypto_uniswap.go
+++ b/plugins/crypto_uniswap/crypto_uniswap.go
@@ -27,7 +27,7 @@ var defaultConfig = types.PluginConfig{
 	Scheme:             "wss",                                        // both http/s ws/s works for this plugin
 	Endpoint:           "rpc-internal-1.piccadilly.autonity.org/ws",  // default websocket endpoint for piccadilly network.
 	Timeout:            10,                                           // 10s
-	DataUpdateInterval: 30,                                           // 30s
+	DataUpdateInterval: 1,                                            // 1s, shorten the default data point refresh interval for AMM market data, as they can move very fast.
 	NTNTokenAddress:    NTNTokenAddress.Hex(),                        // Same as 0xBd770416a3345F91E4B34576cb804a576fa48EB1, Autonity contract address.
 	ATNTokenAddress:    "0xcE17e51cE4F0417A1aB31a3c5d6831ff3BbFa1d2", // Wrapped ATN ERC20 contract address on the target blockchain.
 	USDCTokenAddress:   "0xB855D5e83363A4494e09f0Bb3152A70d3f161940", // USDCx ERC20 contract address on the target blockchain.


### PR DESCRIPTION
This PR contains:
1. The removal of simulator plugin from the built binary set of Piccadilly Network plugins.
2. Update the default refresh interval with 1s of the AMM plugin to shorten the delay of data point from AMM. This is important to reduce the slashing risk as the data point in AMM could move fast.



