### PR TITLE
feature, adapt with no reveal penalty protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The configuration file:
 ```yaml
 # Oracle Server Configuration
 
+# Below is the list of default configuration for oracle server:
 logLevel: 3  # Logging verbosity: 0: NoLevel, 1: Trace, 2: Debug, 3: Info, 4: Warn, 5: Error
 gasTipCap: 1000000000  # 1GWei, the gas priority fee cap for oracle vote message which will be reimbursed by Autonity network.
 

--- a/config/config_for_test.yml
+++ b/config/config_for_test.yml
@@ -1,5 +1,6 @@
 # Oracle Server Configuration
 
+# Below is the list of default configuration for oracle server:
 logLevel: 3  # Logging verbosity: 0: NoLevel, 1: Trace, 2: Debug, 3: Info, 4: Warn, 5: Error
 gasTipCap: 1000000000  # 1GWei, the gas priority fee cap for oracle vote message which will be reimbursed by Autonity network.
 

--- a/config/oracle_config.yml
+++ b/config/oracle_config.yml
@@ -1,5 +1,6 @@
 # Oracle Server Configuration
 
+# Below is the list of default configuration for oracle server:
 logLevel: 3  # Logging verbosity: 0: NoLevel, 1: Trace, 2: Debug, 3: Info, 4: Warn, 5: Error
 gasTipCap: 1000000000  # 1GWei, the gas priority fee cap for oracle vote message which will be reimbursed by Autonity network.
 

--- a/oracle_server/oracle_server.go
+++ b/oracle_server/oracle_server.go
@@ -508,16 +508,19 @@ func (os *OracleServer) handleRoundVote() error {
 		return nil
 	}
 
-	// assemble round data.
-	curRoundData, err := os.buildRoundData(os.curRound)
-	// if the voter failed to assemble current round data, but it has last round data available, then reveal it.
-	if err != nil && lastRoundData != nil && isVoter {
-		return os.reportWithoutCommitment(lastRoundData)
-	}
-
-	// round data was successfully assembled, save current round data.
-	os.roundData[os.curRound] = curRoundData
 	if isVoter {
+		// a voter need to assemble current round data to report it.
+		curRoundData, err := os.buildRoundData(os.curRound)
+		// if the voter failed to assemble current round data, but it has last round data available, then reveal it.
+		if err != nil {
+			if lastRoundData != nil {
+				return os.reportWithoutCommitment(lastRoundData)
+			}
+			return err
+		}
+
+		// round data was successfully assembled, save current round data.
+		os.roundData[os.curRound] = curRoundData
 		if metrics.Enabled {
 			isVoterFlag.Update(1)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -23,6 +23,7 @@ var (
 	ErrNoAvailablePrice  = errors.New("no available prices collected yet")
 	ErrNoDataRound       = errors.New("no data collected at current round")
 	ErrNoSymbolsObserved = errors.New("no symbols observed from oracle contract")
+	ErrMissingDataPoint  = errors.New("missing data point")
 	ErrMissingServiceKey = errors.New("the key to access the data source is missing, please check the plugin config")
 )
 
@@ -50,7 +51,6 @@ type RoundData struct {
 	Prices         PriceBySymbol
 	Symbols        []string
 	Reports        []contract.IOracleReport
-	MissingData    bool
 }
 
 // JSONRPCMessage is the JSON spec to carry those data response from the binance data simulator.


### PR DESCRIPTION
To align with the no-reveal-penalty protocol, oracle server has to adapt the protocol:
1. Round which misses data point won't report with its round commitment, however to reveal last round commitment, it reports with last round data if the last round data is avaiable.
2. If last round and current round data is not available, skip the reporting.