### PR TITLE
improvement, improve confidence strategy with data source confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,22 @@ pluginDir: "./plugins"  # Directory for plugins
 #Set the profiling report directory, where some runtime state will be saved at.
 profileDir: "."  # Profile directory
 
-#Set the confidence strategy, available strategies are: 0: linear, 1: fixed.
-confidenceStrategy: 0  # 0: linear, 1: fixed
+#Confidence and confidence strategies:
+#Each plugin can be configured with a confidence value within the range of [1, 100]. A higher confidence value
+#indicates better data quality provided by the data source. User can config multiple plugins of different data sources
+#to maintain high availability of data, setting one of them with higher confidence as primary, and the others as backup
+# with lower confidence.
+
+# Available strategies:
+# When there are multiple data sources, the strategies determine the data aggregation and confidence computing:
+# 0: max - Selects the data sample from the plugin with the highest confidence for data reporting.
+#  In the plugin config section, users can assign a confidence value (ranging from [1 to 100]) to each plugin.
+#  When multiple samples from different data sources have equal confidence, for currencies without collected volume data,
+#  it performs a confidence - weighted price calculation for data submission.
+
+# 1: linear - For currencies without collected volume data, it uses a confidence - weighted price for data submission.
+#  For currencies with collected volume data, it takes a volume - weighted price for submission.
+confidenceStrategy: 0  # 0: max, 1: linear, default value is 0.
 
 #Set the plugin configs.
 # The forex data plugins are used to fetch realtime rate of currency pairs:
@@ -97,45 +111,53 @@ confidenceStrategy: 0  # 0: linear, 1: fixed
 # namely `name` and `key`. The configuration settings of a plugin are:
 #
 
-# // PluginConfig carry the configuration of plugins.
+#  // PluginConfig is the schema of plugins' config.
 #  type PluginConfig struct {
-#  Name               string `json:"name" yaml:"name"`                         // the name of the plugin binary.
-#  Key                string `json:"key" yaml:"key"`                           // the API key granted by your data provider to access their data API.
-#  Scheme             string `json:"scheme" yaml:"scheme"`                     // the data service scheme, http or https.
-#  Endpoint           string `json:"endpoint" yaml:"endpoint"`                 // the data service endpoint url of the data provider.
-#  Timeout            int    `json:"timeout" yaml:"timeout"`                   // the timeout period in seconds that an API request is lasting for.
-#  DataUpdateInterval int    `json:"refresh" yaml:"refresh"`                   // the interval in seconds to fetch data from data provider due to rate limit.
-#  NTNTokenAddress    string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
-#  ATNTokenAddress    string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
-#  USDCTokenAddress   string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // USDCx erc20 token address on the target blockchain.
-#  SwapAddress        string `json:"swapAddress" yaml:"swapAddress"`           // UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
-#  Disabled           bool   `json:"disabled" yaml:"disabled"`                 // The flag to disable/enable a plugin.
-#}
+#  Name               string `json:"name" yaml:"name"`         // The name of the plugin binary.
+#  Key                string `json:"key" yaml:"key"`           // The API key granted by your data provider to access their data API.
+#  Scheme             string `json:"scheme" yaml:"scheme"`     // The data service scheme, http or https.
+#  Disabled           bool   `json:"disabled" yaml:"disabled"` // The flag to disable a plugin.
+#  Endpoint           string `json:"endpoint" yaml:"endpoint"` // The data service endpoint url of the data provider.
+#  Timeout            int    `json:"timeout" yaml:"timeout"`   // The timeout period in seconds that an API request is lasting for.
+#  DataUpdateInterval int    `json:"refresh" yaml:"refresh"`   // The interval in seconds to fetch data from data provider due to rate limit.
+#  Confidence         uint8  `json:"confidence" yaml:"confidence"` // The confidence of the data that are going to be sourced from the provider's service. Valid range is [0, 100].
+#  // Below configurations are reserved only for on-chain AMM marketplaces.
+#  NTNTokenAddress  string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
+#  ATNTokenAddress  string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
+#  USDCTokenAddress string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // The USDC erc20 token address on the target blockchain.
+#  SwapAddress      string `json:"swapAddress" yaml:"swapAddress"`           // The UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
+}
 
 # Un-comment below lines to enable your forex data plugin's configuration on demand. Your production configurations start from below:
 #pluginConfigs:
 #  - name: forex_currencyfreaks              # required, it is the plugin file name in the plugin directory.
 #    key: 175aab9e47e54790bf6d502c48407c10   # required, visit https://currencyfreaks.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_openexchange                # required, it is the plugin file name in the plugin directory.
 #    key: 1be02ca33c4843ee968c4cedd2686f01   # required, visit https://openexchangerates.org to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_currencylayer               # required, it is the plugin file name in the plugin directory.
 #    key: 105af082ac7f7d150c87303d4e2f049e   # required, visit https://currencylayer.com  to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_exchangerate                # required, it is the plugin file name in the plugin directory.
 #    key: 111f04e4775bb86c20296530           # required, visit https://www.exchangerate-api.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
-#  - name: forex_wise              # required, it is the plugin file name in the plugin directory.
-#    key: 1234          # required, visit https://www.wise.com to get your key, and replace it.
-#    refresh: 30                           # optional, buffered data within 30s, recommended for API rate limited data source.
-# Un-comment below lines to config the RPC endpoint of a Piccadilly Network Full Node for your AMM plugin which sources ATN & NTN market data from an on-chain AMM.
+#  - name: forex_wise                        # required, it is the plugin file name in the plugin directory.
+#    key: 1234                               # required, visit https://www.wise.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
+#    refresh: 30                             # optional, buffered data within 30s, recommended for API rate limited data source.
+# Un-comment below lines to config the RPC endpoint of a Piccadilly Network Validator Node for your AMM plugin which sources ATN & NTN market data from an on-chain AMM.
 #  - name: crypto_uniswap
-#    scheme: "wss"                                          # Available values are: "http", "https", "ws" or "wss", default value is "wss".
+#    scheme: "wss"                           # Only websocket please, available values are: "ws" or "wss", default value is "wss" for uniswap plugins.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    endpoint: "rpc-internal-1.piccadilly.autonity.org/ws"  # The default URL might not be stable for public usage, we recommend you to change it with your validator node's RPC endpoint.
 
 #Enable the metric collection for oracle server, supported TS-DB engines are influxDB v1 and v2.

--- a/config/config_for_test.yml
+++ b/config/config_for_test.yml
@@ -90,6 +90,7 @@ pluginConfigs:
   - name: crypto_uniswap
     scheme: "wss"                                          # Available values are: "ws" or "wss", default value is "wss".
     endpoint: "rpc-internal-1.piccadilly.autonity.org/ws"  # The default URL might not be stable for public usage, we recommend you to change it with your validator node's RPC endpoint.
+    confidence: 100                         # optional, the data confidence of the data service.
 
 #Enable the metric collection for oracle server, supported TS-DB engines are influxDB v1 and v2.
 metricConfigs:

--- a/config/oracle_config.yml
+++ b/config/oracle_config.yml
@@ -24,8 +24,22 @@ pluginDir: "./plugins"  # Directory for plugins
 #Set the profiling report directory, where some runtime state will be saved at.
 profileDir: "."  # Profile directory
 
-#Set the confidence strategy, available strategies are: 0: linear, 1: fixed.
-confidenceStrategy: 0  # 0: linear, 1: fixed
+#Confidence and confidence strategies:
+#Each plugin can be configured with a confidence value within the range of [1, 100]. A higher confidence value
+#indicates better data quality provided by the data source. User can config multiple plugins of different data sources
+#to maintain high availability of data, setting one of them with higher confidence as primary, and the others as backup
+# with lower confidence.
+
+# Available strategies:
+# When there are multiple data sources, the strategies determine the data aggregation and confidence computing:
+# 0: max - Selects the data sample from the plugin with the highest confidence for data reporting.
+#  In the plugin config section, users can assign a confidence value (ranging from [1 to 100]) to each plugin.
+#  When multiple samples from different data sources have equal confidence, for currencies without collected volume data,
+#  it performs a confidence - weighted price calculation for data submission.
+
+# 1: linear - For currencies without collected volume data, it uses a confidence - weighted price for data submission.
+#  For currencies with collected volume data, it takes a volume - weighted price for submission.
+confidenceStrategy: 0  # 0: max, 1: linear, default value is 0.
 
 #Set the plugin configs.
 # The forex data plugins are used to fetch realtime rate of currency pairs:
@@ -54,45 +68,53 @@ confidenceStrategy: 0  # 0: linear, 1: fixed
 # namely `name` and `key`. The configuration settings of a plugin are:
 #
 
-# // PluginConfig carry the configuration of plugins.
+#  // PluginConfig is the schema of plugins' config.
 #  type PluginConfig struct {
-#  Name               string `json:"name" yaml:"name"`                         // the name of the plugin binary.
-#  Key                string `json:"key" yaml:"key"`                           // the API key granted by your data provider to access their data API.
-#  Scheme             string `json:"scheme" yaml:"scheme"`                     // the data service scheme, http, https, ws or wss.
-#  Endpoint           string `json:"endpoint" yaml:"endpoint"`                 // the data service endpoint url of the data provider.
-#  Timeout            int    `json:"timeout" yaml:"timeout"`                   // the timeout period in seconds that an API request is lasting for.
-#  DataUpdateInterval int    `json:"refresh" yaml:"refresh"`                   // the interval in seconds to fetch data from data provider due to rate limit.
-#  NTNTokenAddress    string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
-#  ATNTokenAddress    string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
-#  USDCTokenAddress   string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // USDCx erc20 token address on the target blockchain.
-#  SwapAddress        string `json:"swapAddress" yaml:"swapAddress"`           // UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
-#  Disabled           bool   `json:"disabled" yaml:"disabled"`                 // The flag to disable/enable a plugin.
-#}
+#  Name               string `json:"name" yaml:"name"`         // The name of the plugin binary.
+#  Key                string `json:"key" yaml:"key"`           // The API key granted by your data provider to access their data API.
+#  Scheme             string `json:"scheme" yaml:"scheme"`     // The data service scheme, http or https.
+#  Disabled           bool   `json:"disabled" yaml:"disabled"` // The flag to disable a plugin.
+#  Endpoint           string `json:"endpoint" yaml:"endpoint"` // The data service endpoint url of the data provider.
+#  Timeout            int    `json:"timeout" yaml:"timeout"`   // The timeout period in seconds that an API request is lasting for.
+#  DataUpdateInterval int    `json:"refresh" yaml:"refresh"`   // The interval in seconds to fetch data from data provider due to rate limit.
+#  Confidence         uint8  `json:"confidence" yaml:"confidence"` // The confidence of the data that are going to be sourced from the provider's service. Valid range is [0, 100].
+#  // Below configurations are reserved only for on-chain AMM marketplaces.
+#  NTNTokenAddress  string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
+#  ATNTokenAddress  string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
+#  USDCTokenAddress string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // The USDC erc20 token address on the target blockchain.
+#  SwapAddress      string `json:"swapAddress" yaml:"swapAddress"`           // The UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
+}
 
 # Un-comment below lines to enable your forex data plugin's configuration on demand. Your production configurations start from below:
 #pluginConfigs:
 #  - name: forex_currencyfreaks              # required, it is the plugin file name in the plugin directory.
 #    key: 175aab9e47e54790bf6d502c48407c10   # required, visit https://currencyfreaks.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_openexchange                # required, it is the plugin file name in the plugin directory.
 #    key: 1be02ca33c4843ee968c4cedd2686f01   # required, visit https://openexchangerates.org to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_currencylayer               # required, it is the plugin file name in the plugin directory.
 #    key: 105af082ac7f7d150c87303d4e2f049e   # required, visit https://currencylayer.com  to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_exchangerate                # required, it is the plugin file name in the plugin directory.
 #    key: 111f04e4775bb86c20296530           # required, visit https://www.exchangerate-api.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 3600                           # optional, buffered data within 3600s, recommended for API rate limited data source.
 
 #  - name: forex_wise                        # required, it is the plugin file name in the plugin directory.
 #    key: 1234                               # required, visit https://www.wise.com to get your key, and replace it.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    refresh: 30                             # optional, buffered data within 30s, recommended for API rate limited data source.
 # Un-comment below lines to config the RPC endpoint of a Piccadilly Network Validator Node for your AMM plugin which sources ATN & NTN market data from an on-chain AMM.
 #  - name: crypto_uniswap
-#    scheme: "wss"                                          # Only websocket please, available values are: "ws" or "wss", default value is "wss" for uniswap plugins.
+#    scheme: "wss"                           # Only websocket please, available values are: "ws" or "wss", default value is "wss" for uniswap plugins.
+#    confidence: 60                          # optional, the user can decide the data confidence base on the data quality of the data service. Valid range is [0, 100], the higher value the better data quality is.
 #    endpoint: "rpc-internal-1.piccadilly.autonity.org/ws"  # The default URL might not be stable for public usage, we recommend you to change it with your validator node's RPC endpoint.
 
 #Enable the metric collection for oracle server, supported TS-DB engines are influxDB v1 and v2.

--- a/config/oracle_config.yml
+++ b/config/oracle_config.yml
@@ -90,7 +90,7 @@ confidenceStrategy: 0  # 0: linear, 1: fixed
 #  - name: forex_wise                        # required, it is the plugin file name in the plugin directory.
 #    key: 1234                               # required, visit https://www.wise.com to get your key, and replace it.
 #    refresh: 30                             # optional, buffered data within 30s, recommended for API rate limited data source.
-# Un-comment below lines to config the RPC endpoint of a Piccadilly Network Full Node for your AMM plugin which sources ATN & NTN market data from an on-chain AMM.
+# Un-comment below lines to config the RPC endpoint of a Piccadilly Network Validator Node for your AMM plugin which sources ATN & NTN market data from an on-chain AMM.
 #  - name: crypto_uniswap
 #    scheme: "wss"                                          # Only websocket please, available values are: "ws" or "wss", default value is "wss" for uniswap plugins.
 #    endpoint: "rpc-internal-1.piccadilly.autonity.org/ws"  # The default URL might not be stable for public usage, we recommend you to change it with your validator node's RPC endpoint.

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -36,43 +36,6 @@ func TestResolveSimulatedPrice(t *testing.T) {
 	require.Equal(t, true, pATNUSD.Equal(p))
 }
 
-func TestMedian(t *testing.T) {
-	t.Run("normal cases with 1 sample", func(t *testing.T) {
-		var prices = []decimal.Decimal{decimal.RequireFromString("1.0")}
-		aggPrice, err := Median(prices)
-		require.NoError(t, err)
-		aggPrice.Equals(decimal.RequireFromString("1.0"))
-	})
-	t.Run("normal cases with 2 samples", func(t *testing.T) {
-		var prices = []decimal.Decimal{decimal.RequireFromString("2.0"), decimal.RequireFromString("1.0")}
-		aggPrice, err := Median(prices)
-		require.NoError(t, err)
-		aggPrice.Equals(decimal.RequireFromString("1.5"))
-	})
-	t.Run("normal cases with 3 samples", func(t *testing.T) {
-		var prices = []decimal.Decimal{decimal.RequireFromString("1.0"),
-			decimal.RequireFromString("2.0"), decimal.RequireFromString("3.0")}
-		aggPrice, err := Median(prices)
-		require.NoError(t, err)
-		aggPrice.Equals(decimal.RequireFromString("2.0"))
-	})
-
-	t.Run("normal cases with 4 samples", func(t *testing.T) {
-		var prices = []decimal.Decimal{decimal.RequireFromString("1.0"),
-			decimal.RequireFromString("2.0"), decimal.RequireFromString("3.0"),
-			decimal.RequireFromString("4.0")}
-
-		aggPrice, err := Median(prices)
-		require.NoError(t, err)
-		aggPrice.Equals(decimal.RequireFromString("2.5"))
-	})
-
-	t.Run("with an empty prices set", func(t *testing.T) {
-		_, err := Median(nil)
-		require.Error(t, err)
-	})
-}
-
 func TestVWAP(t *testing.T) {
 	tests := []struct {
 		prices             []decimal.Decimal
@@ -130,7 +93,7 @@ func TestVWAP(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		vwap, highestVol, err := VWAP(test.prices, test.volumes)
+		vwap, _, err := XWAP(test.prices, test.volumes)
 
 		if test.expectError {
 			if err == nil {
@@ -145,11 +108,7 @@ func TestVWAP(t *testing.T) {
 		}
 
 		if !vwap.Equal(test.expectedVWAP) {
-			t.Errorf("For prices: %v and volumes: %v, expected VWAP: %s, but got: %s", test.prices, test.volumes, test.expectedVWAP.String(), vwap.String())
-		}
-
-		if highestVol.Cmp(test.expectedHighestVol) != 0 {
-			t.Errorf("For prices: %v and volumes: %v, expected highest volume: %s, but got: %s", test.prices, test.volumes, test.expectedHighestVol.String(), highestVol.String())
+			t.Errorf("For prices: %v and volumes: %v, expected XWAP: %s, but got: %s", test.prices, test.volumes, test.expectedVWAP.String(), vwap.String())
 		}
 	}
 }

--- a/oracle_server/oracle_server_test.go
+++ b/oracle_server/oracle_server_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"io/ioutil" //nolint
-	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -517,49 +516,4 @@ func removePlugins(pluginDir string) error {
 		}
 	}
 	return nil
-}
-
-// TestComputeConfidence tests the ComputeConfidence function.
-func TestComputeConfidence(t *testing.T) {
-	tests := []struct {
-		symbol       string
-		numOfSamples int
-		strategy     int
-		expected     uint8
-	}{
-		// Forex symbols with ConfidenceStrategyFixed, max confidence are expected.
-		{"AUD-USD", 1, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"CAD-USD", 2, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"EUR-USD", 3, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"GBP-USD", 4, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"JPY-USD", 5, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"SEK-USD", 10, config.ConfidenceStrategyFixed, MaxConfidence},
-
-		// Forex symbols with ConfidenceStrategyLinear
-		{"AUD-USD", 1, config.ConfidenceStrategyLinear, uint8(BaseConfidence + SourceScalingFactor*uint64(math.Pow(1.75, 1)))}, //nolint
-		{"CAD-USD", 2, config.ConfidenceStrategyLinear, uint8(BaseConfidence + SourceScalingFactor*uint64(math.Pow(1.75, 2)))}, //nolint
-		{"EUR-USD", 3, config.ConfidenceStrategyLinear, uint8(BaseConfidence + SourceScalingFactor*uint64(math.Pow(1.75, 3)))}, //nolint
-		{"GBP-USD", 4, config.ConfidenceStrategyLinear, MaxConfidence},
-		{"JPY-USD", 5, config.ConfidenceStrategyLinear, MaxConfidence},
-		{"SEK-USD", 10, config.ConfidenceStrategyLinear, MaxConfidence},
-
-		// Non-forex symbols with ConfidenceStrategyLinear, max confidence are expected.
-		{"ATN-USD", 1, config.ConfidenceStrategyLinear, MaxConfidence},
-		{"NTN-USD", 1, config.ConfidenceStrategyLinear, MaxConfidence},
-		{"NTN-ATN", 1, config.ConfidenceStrategyLinear, MaxConfidence},
-
-		// Non-forex symbols with ConfidenceStrategyFixed, max confidence are expected.
-		{"ATN-USD", 1, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"NTN-USD", 1, config.ConfidenceStrategyFixed, MaxConfidence},
-		{"NTN-ATN", 1, config.ConfidenceStrategyFixed, MaxConfidence},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.symbol, func(t *testing.T) {
-			got := ComputeConfidence(tt.symbol, tt.numOfSamples, tt.strategy)
-			if got != tt.expected {
-				t.Errorf("ComputeConfidence(%q, %d, %d) = %d; want %d", tt.symbol, tt.numOfSamples, tt.strategy, got, tt.expected)
-			}
-		})
-	}
 }

--- a/plugin_wrapper/plugin_wrapper_test.go
+++ b/plugin_wrapper/plugin_wrapper_test.go
@@ -34,43 +34,43 @@ func TestPluginWrapper(t *testing.T) {
 		}
 
 		target := now
-		price, err := p.AggregatedPrice("NTNGBP", target)
+		price, err := p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now, price.Timestamp)
 
 		// upper bound
 		target = now + 100
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now+59, price.Timestamp)
 
 		// lower bound
 		target = now - 1
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now, price.Timestamp)
 
 		// middle
 		target = now + 29
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now+28, price.Timestamp)
 
 		// middle
 		target = now + 33
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now+35, price.Timestamp)
 
 		// middle
 		target = now + 34
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now+35, price.Timestamp)
 
 		// middle
 		target = now + 35
-		price, err = p.AggregatedPrice("NTNGBP", target)
+		price, err = p.SelectSample("NTNGBP", target)
 		require.NoError(t, err)
 		require.Equal(t, now+35, price.Timestamp)
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -6,18 +6,19 @@ Every plugin has a unified configuration, that is configured by oracle server in
 ```go
 // PluginConfig is the schema of plugins' config.
 type PluginConfig struct {
-	Name               string `json:"name" yaml:"name"`                         // The name of the plugin binary.
-	Key                string `json:"key" yaml:"key"`                           // The API key granted by your data provider to access their data API.
-	Scheme             string `json:"scheme" yaml:"scheme"`                     // The data service scheme, http or https.
-	Disabled           bool   `json:"disabled" yaml:"disabled"`                 // The flag to disable a plugin.
-	Endpoint           string `json:"endpoint" yaml:"endpoint"`                 // The data service endpoint url of the data provider.
-	Timeout            int    `json:"timeout" yaml:"timeout"`                   // The timeout period in seconds that an API request is lasting for.
-	DataUpdateInterval int    `json:"refresh" yaml:"refresh"`                   // The interval in seconds to fetch data from data provider due to rate limit.
+	Name               string `json:"name" yaml:"name"`             // The name of the plugin binary.
+	Key                string `json:"key" yaml:"key"`               // The API key granted by your data provider to access their data API.
+	Scheme             string `json:"scheme" yaml:"scheme"`         // The data service scheme, http or https.
+	Disabled           bool   `json:"disabled" yaml:"disabled"`     // The flag to disable a plugin.
+	Endpoint           string `json:"endpoint" yaml:"endpoint"`     // The data service endpoint url of the data provider.
+	Timeout            int    `json:"timeout" yaml:"timeout"`       // The timeout period in seconds that an API request is lasting for.
+	DataUpdateInterval int    `json:"refresh" yaml:"refresh"`       // The interval in seconds to fetch data from data provider due to rate limit.
+	Confidence         uint8  `json:"confidence" yaml:"confidence"` // The confidence of the data that are going to be sourced from the provider's service. Valid range is [0, 100].
 	// Below configurations are reserved only for on-chain AMM marketplaces.
-	NTNTokenAddress    string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
-	ATNTokenAddress    string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
-	USDCTokenAddress   string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // The USDC erc20 token address on the target blockchain.
-	SwapAddress        string `json:"swapAddress" yaml:"swapAddress"`           // The UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
+	NTNTokenAddress  string `json:"ntnTokenAddress" yaml:"ntnTokenAddress"`   // The NTN erc20 token address on the target blockchain.
+	ATNTokenAddress  string `json:"atnTokenAddress" yaml:"atnTokenAddress"`   // The Wrapped ATN erc20 token address on the target blockchain.
+	USDCTokenAddress string `json:"usdcTokenAddress" yaml:"usdcTokenAddress"` // The USDC erc20 token address on the target blockchain.
+	SwapAddress      string `json:"swapAddress" yaml:"swapAddress"`           // The UniSwap factory contract address or AirSwap SwapERC20 contract address on the target blockchain.
 }
 ```
 ## Interface
@@ -64,6 +65,7 @@ type PluginStatement struct {
 	Version          string
 	DataSource       string
 	AvailableSymbols []string
+    Confidence       uint8
 	DataSourceType   DataSourceType
 }
 ```

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -120,10 +120,11 @@ func (p *Plugin) FetchPrices(symbols []string) (types.PluginPriceReport, error) 
 		}
 
 		pr := types.Price{
-			Timestamp: now,
-			Symbol:    availableSymMap[v.Symbol], // set the symbol with the symbol style used in oracle server side.
-			Price:     decPrice,
-			Volume:    decVol,
+			Timestamp:  now,
+			Symbol:     availableSymMap[v.Symbol], // set the symbol with the symbol style used in oracle server side.
+			Price:      decPrice,
+			Confidence: p.conf.Confidence,
+			Volume:     decVol,
 		}
 		p.cachePrices[v.Symbol] = pr
 		report.Prices = append(report.Prices, pr)
@@ -161,6 +162,7 @@ func (p *Plugin) State(chainID int64) (types.PluginStatement, error) {
 	state.Version = p.version
 	state.AvailableSymbols = symbols
 	state.KeyRequired = p.client.KeyRequired()
+	state.Confidence = p.conf.Confidence
 	state.DataSource = p.conf.Scheme + "://" + p.conf.Endpoint
 	state.DataSourceType = p.dataSourceType
 
@@ -252,6 +254,10 @@ func ResolveConf(cmd string, defConf *config.PluginConfig) *config.PluginConfig 
 	if err != nil {
 		println("cannot load conf: ", err.Error(), cmd)
 		os.Exit(-1)
+	}
+
+	if conf.Confidence == 0 || conf.Confidence > types.MaxConfidence {
+		conf.Confidence = defConf.Confidence
 	}
 
 	if conf.Timeout == 0 {

--- a/plugins/crypto_coinbase/crypto_coinbase.go
+++ b/plugins/crypto_coinbase/crypto_coinbase.go
@@ -22,6 +22,7 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "api.coinbase.com",
+	Confidence:         90, // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10, // 10s
 	DataUpdateInterval: 30, // 30s, tested and passed the rate limit policy of public data service of coinbase.
 }
@@ -88,7 +89,7 @@ func (c *CoinBaseClient) FetchPrice(_ []string) (common.Prices, error) {
 	prices = append(prices, common.Price{
 		Symbol: common.DefaultUSDCSymbol,
 		Price:  data.Data.Amount,
-		Volume: types.DefaultVolume.String(),
+		Volume: types.NoVolumeData.String(),
 	})
 
 	return prices, nil

--- a/plugins/crypto_coingecko/crypto_coingecko.go
+++ b/plugins/crypto_coingecko/crypto_coingecko.go
@@ -28,6 +28,7 @@ var defaultConfig = config.PluginConfig{
 	Scheme:             "https",
 	Endpoint:           "api.coingecko.com",
 	Timeout:            10, // 10s
+	Confidence:         90, // range from [1, 100], the higher, the better data quality is.
 	DataUpdateInterval: 30, // 30s, tested and passed the rate limit policy of public data service of coin-gecko.
 }
 
@@ -89,7 +90,7 @@ func (c *CoinGeckoClient) FetchPrice(_ []string) (common.Prices, error) {
 	prices = append(prices, common.Price{
 		Symbol: common.DefaultUSDCSymbol,
 		Price:  strconv.FormatFloat(result.USDCoin.USD, 'f', 6, 64),
-		Volume: types.DefaultVolume.String(),
+		Volume: types.NoVolumeData.String(),
 	})
 
 	return prices, nil

--- a/plugins/crypto_kraken/crypto_kraken.go
+++ b/plugins/crypto_kraken/crypto_kraken.go
@@ -26,6 +26,7 @@ var defaultConfig = config.PluginConfig{
 	Scheme:             "https",
 	Endpoint:           "api.kraken.com",
 	Timeout:            10, // 10s
+	Confidence:         90, // range from [1, 100], the higher, the better data quality is.
 	DataUpdateInterval: 30, // 30s, tested and passed the rate limit policy of public data service of kraken.
 }
 
@@ -122,7 +123,7 @@ func (k *KrakenClient) toPrice(symbol string, res *Response) (common.Price, erro
 
 	price.Symbol = symbol
 	price.Price = usdcResult.P[0] // take the volume weighted average price of today.
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	return price, nil
 }
 

--- a/plugins/crypto_uniswap/common/client.go
+++ b/plugins/crypto_uniswap/common/client.go
@@ -28,6 +28,7 @@ var (
 	NTNUSDC           = "NTN-USDC"
 	supportedSymbols  = common.DefaultCryptoSymbols
 	NTNTokenAddress   = types.AutonityContractAddress // Autonity protocol contract is the NTN token contract.
+	initialVolume     = new(big.Int).SetUint64(100)   // The initial volume used before a swap event happens.
 )
 
 type Order struct {
@@ -447,7 +448,7 @@ func (e *UniswapClient) fetchPrice(pair *WrappedPair, symbol string) (common.Pri
 
 	price.Symbol = symbol
 	price.Price = p.String()
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = initialVolume.String()
 	return price, nil
 }
 

--- a/plugins/crypto_uniswap/uniswap_usdcx/bakerloo/crypto_uniswap_usdcx.go
+++ b/plugins/crypto_uniswap/uniswap_usdcx/bakerloo/crypto_uniswap_usdcx.go
@@ -15,6 +15,7 @@ var defaultConfig = config.PluginConfig{
 	Scheme:             "wss",                                        // both http/s ws/s works for this plugin
 	Endpoint:           "rpc-internal-1.bakerloo.autonity.org/ws",    // default websocket endpoint for bakerloo network.
 	Timeout:            10,                                           // 10s
+	Confidence:         90,                                           // range from [1, 100], the higher, the better data quality is.
 	DataUpdateInterval: common.DefaultAMMDataUpdateInterval,          // 1s, shorten the default data point refresh interval for AMM market data, as they can move very fast.
 	NTNTokenAddress:    types.AutonityContractAddress.Hex(),          // Same as 0xBd770416a3345F91E4B34576cb804a576fa48EB1, Autonity contract address.
 	ATNTokenAddress:    "0xcE17e51cE4F0417A1aB31a3c5d6831ff3BbFa1d2", // Wrapped ATN ERC20 contract address on the target blockchain.

--- a/plugins/crypto_uniswap/uniswap_usdcx/mainnet/crypto_uniswap_usdcx.go
+++ b/plugins/crypto_uniswap/uniswap_usdcx/mainnet/crypto_uniswap_usdcx.go
@@ -14,6 +14,7 @@ var defaultConfig = config.PluginConfig{
 	Name:               "crypto_uniswap",
 	Scheme:             "wss",                                        // both http/s ws/s works for this plugin
 	Endpoint:           "rpc-internal-1.mainnet.autonity.org/ws",     // default websocket endpoint for autonity main network.
+	Confidence:         90,                                           // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10,                                           // 10s
 	DataUpdateInterval: common.DefaultAMMDataUpdateInterval,          // 1s, shorten the default data point refresh interval for AMM market data, as they can move very fast.
 	NTNTokenAddress:    types.AutonityContractAddress.Hex(),          // Same as 0xBd770416a3345F91E4B34576cb804a576fa48EB1, Autonity contract address.

--- a/plugins/crypto_uniswap/uniswap_usdcx/piccadilly/crypto_uniswap_usdcx.go
+++ b/plugins/crypto_uniswap/uniswap_usdcx/piccadilly/crypto_uniswap_usdcx.go
@@ -13,6 +13,7 @@ var defaultConfig = config.PluginConfig{
 	Name:               "crypto_uniswap",
 	Scheme:             "wss",                                        // both http/s ws/s works for this plugin
 	Endpoint:           "rpc-internal-1.piccadilly.autonity.org/ws",  // default websocket endpoint for piccadilly network.
+	Confidence:         90,                                           // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10,                                           // 10s
 	DataUpdateInterval: common.DefaultAMMDataUpdateInterval,          // 1s, shorten the default data point refresh interval for AMM market data, as they can move very fast.
 	NTNTokenAddress:    types.AutonityContractAddress.Hex(),          // Same as 0xBd770416a3345F91E4B34576cb804a576fa48EB1, Autonity contract address.

--- a/plugins/forex_currencyfreaks/forex_currencyfreaks.go
+++ b/plugins/forex_currencyfreaks/forex_currencyfreaks.go
@@ -26,8 +26,9 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "api.currencyfreaks.com",
-	Timeout:            10, //10s
-	DataUpdateInterval: 30, //30s
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   //10s
+	DataUpdateInterval: 30,                   //30s
 }
 
 type CFResult struct {
@@ -133,7 +134,7 @@ func (cf *CFClient) symbolsToPrice(s string, res *CFResult) (common.Price, error
 		return price, fmt.Errorf("wrong base %s", to)
 	}
 	price.Symbol = s
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	switch from {
 	case "EUR":
 		pUE, err := decimal.NewFromString(res.Rates.EUR)

--- a/plugins/forex_currencylayer/forex_currencylayer.go
+++ b/plugins/forex_currencylayer/forex_currencylayer.go
@@ -26,8 +26,9 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "http",
 	Endpoint:           "api.currencylayer.com",
-	Timeout:            10, //10s
-	DataUpdateInterval: 30, //30s
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   //10s
+	DataUpdateInterval: 30,                   //30s
 }
 
 type CLResult struct {
@@ -139,7 +140,7 @@ func (cl *CLClient) symbolsToPrice(s string, res *CLResult) (common.Price, error
 	}
 
 	price.Symbol = s
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	switch from {
 	case "EUR":
 		price.Price = decimal.NewFromInt(1).Div(res.Quotes.USDEUR).String()

--- a/plugins/forex_exchangerate/forex_exchangerate.go
+++ b/plugins/forex_exchangerate/forex_exchangerate.go
@@ -25,8 +25,9 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "v6.exchangerate-api.com",
-	Timeout:            10, //10s
-	DataUpdateInterval: 30, //30s
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   //10s
+	DataUpdateInterval: 30,                   //30s
 }
 
 type EXResult struct {
@@ -140,7 +141,7 @@ func (ex *EXClient) symbolsToPrice(s string, res *EXResult) (common.Price, error
 	}
 
 	price.Symbol = s
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	switch from {
 	case "EUR":
 		price.Price = decimal.NewFromInt(1).Div(res.Rates.EUR).String()

--- a/plugins/forex_openexchange/forex_openexchange.go
+++ b/plugins/forex_openexchange/forex_openexchange.go
@@ -27,8 +27,9 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "openexchangerates.org",
-	Timeout:            10, //10s
-	DataUpdateInterval: 30, //30s
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   //10s
+	DataUpdateInterval: 30,                   //30s
 }
 
 type ConversionRates struct {
@@ -139,7 +140,7 @@ func (oe *OXClient) symbolsToPrice(s string, res *OEResult) (common.Price, error
 		return price, fmt.Errorf("wrong base %s", to)
 	}
 	price.Symbol = s
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	switch from {
 	case "EUR":
 		price.Price = decimal.NewFromInt(1).Div(res.Rates.EUR).String()

--- a/plugins/forex_wise/forex_wise.go
+++ b/plugins/forex_wise/forex_wise.go
@@ -25,7 +25,8 @@ var defaultConfig = config.PluginConfig{
 	Key:                "0x123",
 	Scheme:             "https",
 	Endpoint:           "api.transferwise.com",
-	Timeout:            10, // Timeout in seconds
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   // Timeout in seconds
 	DataUpdateInterval: 30,
 }
 
@@ -155,7 +156,7 @@ func (wc *WiseClient) symbolsToPrice(s string, res *WRResult) (common.Price, err
 	}
 
 	price.Symbol = s
-	price.Volume = types.DefaultVolume.String()
+	price.Volume = types.NoVolumeData.String()
 	switch from {
 	case "EUR":
 		price.Price = decimal.NewFromInt(1).Div(res.Rate).String()

--- a/plugins/outlier_tester/outlier_tester.go
+++ b/plugins/outlier_tester/outlier_tester.go
@@ -20,8 +20,9 @@ const (
 
 var defaultConfig = config.PluginConfig{
 	Name:               "outlier_tester_plugin",
-	Timeout:            10, //10s
-	DataUpdateInterval: 30, //30s
+	Confidence:         types.BaseConfidence, // range from [1, 100], the higher, the better data quality is.
+	Timeout:            10,                   //10s
+	DataUpdateInterval: 30,                   //30s
 }
 
 // OutlierTesterPlugin is only used for internal e2e testing,
@@ -130,6 +131,7 @@ func (g *OutlierTesterPlugin) State(_ int64) (types.PluginStatement, error) {
 	}
 
 	state.KeyRequired = g.client.KeyRequired()
+	state.Confidence = g.conf.Confidence
 	state.Version = g.version
 	state.AvailableSymbols = symbols
 	state.DataSource = g.conf.Scheme + "://" + g.conf.Endpoint
@@ -209,7 +211,7 @@ func (tc *OutlierClient) FetchPrice(symbols []string) (common.Prices, error) {
 	var prices common.Prices
 	for _, s := range symbols {
 		var price common.Price
-		price.Volume = types.DefaultVolume.String()
+		price.Volume = types.NoVolumeData.String()
 		price.Symbol = s
 		// it is a malicious behaviour to set the price into an outlier range by multiply with 3.0
 		p := helpers.ResolveSimulatedPrice(s).Mul(decimal.RequireFromString("3.0"))

--- a/plugins/simulator_plugin/bakerloo/simulator_plugin.go
+++ b/plugins/simulator_plugin/bakerloo/simulator_plugin.go
@@ -13,6 +13,7 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "simfeed.bakerloo.autonity.org",
+	Confidence:         types.BaseConfidence,  // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10, //10s
 	DataUpdateInterval: 10, //10s
 }

--- a/plugins/simulator_plugin/common/client.go
+++ b/plugins/simulator_plugin/common/client.go
@@ -69,7 +69,7 @@ func (bi *SIMClient) FetchPrice(symbols []string) (common.Prices, error) {
 	}
 
 	for i := range prices {
-		prices[i].Volume = types.DefaultVolume.String()
+		prices[i].Volume = types.NoVolumeData.String()
 	}
 
 	return prices, nil

--- a/plugins/simulator_plugin/mainnet/simulator_plugin.go
+++ b/plugins/simulator_plugin/mainnet/simulator_plugin.go
@@ -13,6 +13,7 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "simfeed.mainnet.autonity.org",
+	Confidence:         types.BaseConfidence,  // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10, //10s
 	DataUpdateInterval: 10, //10s
 }

--- a/plugins/simulator_plugin/piccadilly/simulator_plugin.go
+++ b/plugins/simulator_plugin/piccadilly/simulator_plugin.go
@@ -13,6 +13,7 @@ var defaultConfig = config.PluginConfig{
 	Key:                "",
 	Scheme:             "https",
 	Endpoint:           "simfeed.piccadilly.autonity.org",
+	Confidence:         types.BaseConfidence,  // range from [1, 100], the higher, the better data quality is.
 	Timeout:            10, //10s
 	DataUpdateInterval: 10, //10s
 }

--- a/types/plugin_spec.go
+++ b/types/plugin_spec.go
@@ -14,7 +14,6 @@ type DataSourceType int
 const (
 	SrcAMM DataSourceType = iota
 	SrcCEX
-	SrcAFQ
 )
 
 // HandshakeConfig are used to just do a basic handshake between
@@ -40,6 +39,7 @@ type PluginStatement struct {
 	Version          string
 	DataSource       string
 	AvailableSymbols []string
+	Confidence       uint8
 	DataSourceType   DataSourceType
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -13,9 +13,12 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+const MaxConfidence = 100
+const BaseConfidence = 40
+
 var (
 	Deployer                = common.Address{}
-	DefaultVolume           = new(big.Int).SetInt64(1000000) // used by forex currency which does not have trade volumes.
+	NoVolumeData            = new(big.Int).SetInt64(0) // used by those plugins which cannot get volume info from data source.
 	AutonityContractAddress = crypto.CreateAddress(Deployer, 0)
 	OracleContractAddress   = crypto.CreateAddress(Deployer, 2)
 
@@ -32,9 +35,8 @@ type Price struct {
 	Timestamp  int64 // TS on when the data is being sampled in time's seconds since Jan 1 1970 (Unix time).
 	Symbol     string
 	Price      decimal.Decimal
-	Confidence uint8 // confidence of the data point is resolved by the oracle server.
+	Confidence uint8 // confidence of the data point is resolved by the plugin by according to config.
 	// Below field is reserved for data providers which can provide recent trade volumes of the pair,
-	// otherwise it will be resolved by oracle server.
 	Volume *big.Int // recent trade volume in quote of USDCx for on-chain AMM marketplace.
 }
 


### PR DESCRIPTION
This PR contains an improvement of confidence strategy of the oracle server. 
As confidence of data point comes from the data quality subscribed from a data source, it does not come from the availability of data service, thus we let the end user to decide the confidence degree of their data source, so there is a confidence configuration added in the plugin. Now the confidence strategies are explained at README as below:

```yaml
#Confidence and confidence strategies:
#Each plugin can be configured with a confidence value within the range of [1, 100]. A higher confidence value
#indicates better data quality provided by the data source. User can config multiple plugins of different data sources
#to maintain high availability of data, setting one of them with higher confidence as primary, and the others as backup
# with lower confidence.

# Available strategies:
# When there are multiple data sources, the strategies determine the data aggregation and confidence computing:
# 0: max - Selects the data sample from the plugin with the highest confidence for data reporting.
#  In the plugin config section, users can assign a confidence value (ranging from [1 to 100]) to each plugin.
#  When multiple samples from different data sources have equal confidence, for currencies without collected volume data,
#  it performs a confidence - weighted price calculation for data submission.

# 1: linear - For currencies without collected volume data, it uses a confidence - weighted price for data submission.
#  For currencies with collected volume data, it takes a volume - weighted price for submission.
```