### PR TITLE
Improvement, refine the penlize event processing in oracle server.

### DIFF
--- a/oracle_server/oracle_server.go
+++ b/oracle_server/oracle_server.go
@@ -1041,10 +1041,10 @@ func (os *OracleServer) Start() {
 			// of nodes within the oracle network and maintain its operational liveness, we continue to allow these
 			// non-slashed outliers to contribute data samples to the network.
 			if penalizeEvent.SlashingAmount.Cmp(common.Big0) == 0 {
-				os.logger.Warn("Client addressed as an outlier without offense the OutlierSlashingThreshold, "+
-					"it is allowed to continue the reporting", "symbol", penalizeEvent.Symbol, "median value",
+				os.logger.Warn("Client addressed as an outlier, this vote won't be counted for reward distribution, "+
+					"please use high quality data source.", "symbol", penalizeEvent.Symbol, "median value",
 					penalizeEvent.Median.String(), "reported value", penalizeEvent.Reported.String())
-				os.logger.Warn("IMPORTANT: please double check your data source for data precision before getting penalized")
+				os.logger.Warn("IMPORTANT: please double check your data source setup before getting penalized")
 				continue
 			}
 


### PR DESCRIPTION
This PR refine the processing of penlize event in oracle server, as the OutlierDetectionThreshold is set to low level, e.g. 3% against the median, and the OutlierSlashingThreshold is configured at (10%, 15%) which is much higher, a penalization event may occur with zero slashing amount. This indicates that the current client has been identified as an outlier but is not penalized, as its data point falls below the OutlierSlashingThreshold when compared to the median price. To ensure a broader participation
of nodes within the oracle network and maintain its operational liveness, we continue to allow these non-slashed outliers to contribute data samples to the network.
