### PR TITLE
Vote dropped

### DIFF
--- a/contract_binder/contract/interface.go
+++ b/contract_binder/contract/interface.go
@@ -20,6 +20,7 @@ type ContractAPI interface {
 	WatchPenalized(opts *bind.WatchOpts, sink chan<- *OraclePenalized, _participant []common.Address) (event.Subscription, error)
 	WatchSuccessfulVote(opts *bind.WatchOpts, sink chan<- *OracleSuccessfulVote, reporter []common.Address) (event.Subscription, error)
 	WatchInvalidVote(opts *bind.WatchOpts, sink chan<- *OracleInvalidVote, reporter []common.Address) (event.Subscription, error)
+	WatchNewVoter(opts *bind.WatchOpts, sink chan<- *OracleNewVoter) (event.Subscription, error)
 	WatchTotalOracleRewards(opts *bind.WatchOpts, sink chan<- *OracleTotalOracleRewards) (event.Subscription, error)
 	GetRoundData(opts *bind.CallOpts, _round *big.Int, _symbol string) (IOracleRoundData, error)
 	LatestRoundData(opts *bind.CallOpts, _symbol string) (IOracleRoundData, error)

--- a/contract_binder/contract/mock/contract_mock.go
+++ b/contract_binder/contract/mock/contract_mock.go
@@ -219,6 +219,21 @@ func (mr *MockContractAPIMockRecorder) WatchNewSymbols(opts, sink interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNewSymbols", reflect.TypeOf((*MockContractAPI)(nil).WatchNewSymbols), opts, sink)
 }
 
+// WatchNewVoter mocks base method.
+func (m *MockContractAPI) WatchNewVoter(opts *bind.WatchOpts, sink chan<- *oracle.OracleNewVoter) (event.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNewVoter", opts, sink)
+	ret0, _ := ret[0].(event.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNewVoter indicates an expected call of WatchNewVoter.
+func (mr *MockContractAPIMockRecorder) WatchNewVoter(opts, sink interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNewVoter", reflect.TypeOf((*MockContractAPI)(nil).WatchNewVoter), opts, sink)
+}
+
 // WatchPenalized mocks base method.
 func (m *MockContractAPI) WatchPenalized(opts *bind.WatchOpts, sink chan<- *oracle.OraclePenalized, _participant []common.Address) (event.Subscription, error) {
 	m.ctrl.T.Helper()

--- a/types/types.go
+++ b/types/types.go
@@ -19,6 +19,7 @@ var (
 	AutonityContractAddress = crypto.CreateAddress(Deployer, 0)
 	OracleContractAddress   = crypto.CreateAddress(Deployer, 2)
 
+	ErrSkipVote          = errors.New("skip vote to avoid reveal failure")
 	ErrPeerOnSync        = errors.New("l1 node is on peer sync")
 	ErrNoAvailablePrice  = errors.New("no available prices collected yet")
 	ErrNoDataRound       = errors.New("no data collected at current round")
@@ -51,6 +52,7 @@ type RoundData struct {
 	Prices         PriceBySymbol
 	Symbols        []string
 	Reports        []contract.IOracleReport
+	Processed      bool
 }
 
 // JSONRPCMessage is the JSON spec to carry those data response from the binance data simulator.


### PR DESCRIPTION
This PR contains an improvement regarding the voting when the previous vote was dropped from L1 network as it may happens. Oracle server now skip the current round vote if the last round vote was not proccessed (mined) by L1, thus it avoid the reveal failure.  At the round right after the skipped round, vote() TXN just stores commitment hash on-chain without verifying the reveal logics as it recovers from https://github.com/autonity/autonity/blob/develop/autonity/solidity/contracts/Oracle.sol#L181-L184 like a recovery from omission fault.





